### PR TITLE
feat: set status message and get config options of any juju supported type

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ parts:
     build-snaps:
       - go
     organize:
-      bin/goops: dispatch  # replace `goops` with your binary name
+      bin/<your-charm-name>: dispatch
 ```
 
 ### 2. Write your charm
@@ -55,7 +55,7 @@ func main() {
 }
 ```
 
-You can find an example of the library in the [certificates charm](https://github.com/gruyaume/certificates-operator) repository. 
+You can find an example of the library being used in the [certificates charm repository](https://github.com/gruyaume/certificates-operator). 
 
 ## Design principles
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Develop Reliable, Portable, and Fast Juju Charms in Go**
 
-`goops` is a Go library for developing robust Juju charms. While developers traditionally use the [ops Python framework](https://github.com/canonical/operator) for developing charms, Python's dynamic typing and interpreter-based execution often lead to runtime errors and portability issues across different bases. In contrast, Go compiles to a single, self-contained binary, ensuring greater reliability and consistent behavior in any environment.
+`goops` is a Go library for developing robust Juju charms. While charm developers traditionally use the [ops Python framework](https://github.com/canonical/operator), Python's dynamic typing and interpreter-based execution often lead to runtime errors and portability issues across different bases. In contrast, Go compiles to a single, self-contained binary, ensuring greater reliability and consistent behavior in any environment.
 
 ## Try it now
 
@@ -14,7 +14,6 @@
 Use the `go` plugin to build your charm in `charmcraft.yaml`:
 
 ```yaml
-...
 parts:
   charm:
     source: .

--- a/commands/config.go
+++ b/commands/config.go
@@ -9,13 +9,13 @@ const (
 	ConfigGetCommand = "config-get"
 )
 
-func ConfigGet(runner CommandRunner, key string) (string, error) {
+func ConfigGet(runner CommandRunner, key string) (any, error) {
 	args := []string{key, "--format=json"}
 	output, err := runner.Run(ConfigGetCommand, args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to get config: %w", err)
 	}
-	var configValue string
+	var configValue any
 	err = json.Unmarshal(output, &configValue)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse config value: %w", err)

--- a/commands/config.go
+++ b/commands/config.go
@@ -2,12 +2,15 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
 const (
 	ConfigGetCommand = "config-get"
 )
+
+var ErrConfigNotSet = errors.New("config option not set")
 
 func ConfigGet(runner CommandRunner, key string) (any, error) {
 	args := []string{key, "--format=json"}
@@ -21,4 +24,49 @@ func ConfigGet(runner CommandRunner, key string) (any, error) {
 		return "", fmt.Errorf("failed to parse config value: %w", err)
 	}
 	return configValue, nil
+}
+
+func ConfigGetString(runner CommandRunner, key string) (string, error) {
+	value, err := ConfigGet(runner, key)
+	if err != nil {
+		return "", err
+	}
+	if value == nil {
+		return "", ErrConfigNotSet
+	}
+	strValue, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("config value is not a string: %v", value)
+	}
+	return strValue, nil
+}
+
+func ConfigGetInt(runner CommandRunner, key string) (int, error) {
+	value, err := ConfigGet(runner, key)
+	if err != nil {
+		return 0, err
+	}
+	if value == nil {
+		return 0, ErrConfigNotSet
+	}
+	floatValue, ok := value.(float64)
+	if !ok {
+		return 0, fmt.Errorf("config value is not a number: %v", value)
+	}
+	return int(floatValue), nil
+}
+
+func ConfigGetBool(runner CommandRunner, key string) (bool, error) {
+	value, err := ConfigGet(runner, key)
+	if err != nil {
+		return false, err
+	}
+	if value == nil {
+		return false, ErrConfigNotSet
+	}
+	boolValue, ok := value.(bool)
+	if !ok {
+		return false, fmt.Errorf("config value is not a bool: %v", value)
+	}
+	return boolValue, nil
 }

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gruyaume/goops/commands"
 )
 
-func TestConfigGet_Success(t *testing.T) {
+func TestConfigGetString_Success(t *testing.T) {
 	fakeRunner := &FakeRunner{
 		Output: []byte(`"banana"`),
 		Err:    nil,
@@ -20,6 +20,32 @@ func TestConfigGet_Success(t *testing.T) {
 		t.Fatalf("Expected %q, got %q", "banana", result)
 	}
 
+	if fakeRunner.Command != commands.ConfigGetCommand {
+		t.Errorf("Expected command %q, got %q", commands.ConfigGetCommand, fakeRunner.Command)
+	}
+	if len(fakeRunner.Args) != 2 {
+		t.Fatalf("Expected 2 arguments, got %d", len(fakeRunner.Args))
+	}
+	if fakeRunner.Args[0] != "fruit" {
+		t.Errorf("Expected argument %q, got %q", "fruit", fakeRunner.Args[0])
+	}
+	if fakeRunner.Args[1] != "--format=json" {
+		t.Errorf("Expected argument %q, got %q", "--format=json", fakeRunner.Args[1])
+	}
+}
+
+func TestConfigGetFloat64_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`1234`),
+		Err:    nil,
+	}
+	result, err := commands.ConfigGet(fakeRunner, "fruit")
+	if err != nil {
+		t.Fatalf("ConfigGet returned an error: %v", err)
+	}
+	if result != float64(1234) {
+		t.Fatalf("Expected %f, got %f", 1234.0, result)
+	}
 	if fakeRunner.Command != commands.ConfigGetCommand {
 		t.Errorf("Expected command %q, got %q", commands.ConfigGetCommand, fakeRunner.Command)
 	}

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gruyaume/goops/commands"
 )
 
-func TestConfigGetString_Success(t *testing.T) {
+func TestConfigGet_Success(t *testing.T) {
 	fakeRunner := &FakeRunner{
 		Output: []byte(`"banana"`),
 		Err:    nil,
@@ -16,6 +16,11 @@ func TestConfigGetString_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConfigGet returned an error: %v", err)
 	}
+
+	if _, ok := result.(string); !ok {
+		t.Fatalf("Expected result to be a string, got %T", result)
+	}
+
 	if result != "banana" {
 		t.Fatalf("Expected %q, got %q", "banana", result)
 	}
@@ -34,28 +39,87 @@ func TestConfigGetString_Success(t *testing.T) {
 	}
 }
 
-func TestConfigGetFloat64_Success(t *testing.T) {
+func TestConfigGetString_Success(t *testing.T) {
 	fakeRunner := &FakeRunner{
-		Output: []byte(`1234`),
+		Output: []byte(`"banana"`),
 		Err:    nil,
 	}
-	result, err := commands.ConfigGet(fakeRunner, "fruit")
+	result, err := commands.ConfigGetString(fakeRunner, "fruit")
 	if err != nil {
-		t.Fatalf("ConfigGet returned an error: %v", err)
+		t.Fatalf("ConfigGetString returned an error: %v", err)
 	}
-	if result != float64(1234) {
-		t.Fatalf("Expected %f, got %f", 1234.0, result)
+	if result != "banana" {
+		t.Fatalf("Expected %q, got %q", "banana", result)
 	}
-	if fakeRunner.Command != commands.ConfigGetCommand {
-		t.Errorf("Expected command %q, got %q", commands.ConfigGetCommand, fakeRunner.Command)
+
+}
+
+func TestConfigGetString_BadType(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`123`),
+		Err:    nil,
 	}
-	if len(fakeRunner.Args) != 2 {
-		t.Fatalf("Expected 2 arguments, got %d", len(fakeRunner.Args))
+	_, err := commands.ConfigGetString(fakeRunner, "fruit")
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
 	}
-	if fakeRunner.Args[0] != "fruit" {
-		t.Errorf("Expected argument %q, got %q", "fruit", fakeRunner.Args[0])
+	if err.Error() != "config value is not a string: 123" {
+		t.Fatalf("Expected error %q, got %q", "config value is not a string: 123", err.Error())
 	}
-	if fakeRunner.Args[1] != "--format=json" {
-		t.Errorf("Expected argument %q, got %q", "--format=json", fakeRunner.Args[1])
+}
+
+func TestConfigGetInt_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`123`),
+		Err:    nil,
+	}
+	result, err := commands.ConfigGetInt(fakeRunner, "fruit")
+	if err != nil {
+		t.Fatalf("ConfigGetInt returned an error: %v", err)
+	}
+	if result != 123 {
+		t.Fatalf("Expected %d, got %d", 123, result)
+	}
+}
+
+func TestConfigGetInt_BadType(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`"banana"`),
+		Err:    nil,
+	}
+	_, err := commands.ConfigGetInt(fakeRunner, "fruit")
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
+	if err.Error() != "config value is not a number: banana" {
+		t.Fatalf("Expected error %q, got %q", "config value is not a number: banana", err.Error())
+	}
+}
+
+func TestConfigGetBool_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`true`),
+		Err:    nil,
+	}
+	result, err := commands.ConfigGetBool(fakeRunner, "fruit")
+	if err != nil {
+		t.Fatalf("ConfigGetBool returned an error: %v", err)
+	}
+	if result != true {
+		t.Fatalf("Expected %t, got %t", true, result)
+	}
+}
+
+func TestConfigGetBool_BadType(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`123`),
+		Err:    nil,
+	}
+	_, err := commands.ConfigGetBool(fakeRunner, "fruit")
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
+	if err.Error() != "config value is not a bool: 123" {
+		t.Fatalf("Expected error %q, got %q", "config value is not a bool: 123", err.Error())
 	}
 }

--- a/commands/status.go
+++ b/commands/status.go
@@ -16,8 +16,13 @@ const (
 	StatusSetCommand = "status-set"
 )
 
-func StatusSet(runner CommandRunner, status Status) error {
-	_, err := runner.Run(StatusSetCommand, string(status))
+func StatusSet(runner CommandRunner, status Status, message string) error {
+	var args []string
+	args = append(args, string(status))
+	if message != "" {
+		args = append(args, message)
+	}
+	_, err := runner.Run(StatusSetCommand, args...)
 	if err != nil {
 		return fmt.Errorf("failed to set status: %w", err)
 	}

--- a/commands/status_test.go
+++ b/commands/status_test.go
@@ -12,7 +12,7 @@ func TestStatusSet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	err := commands.StatusSet(fakeRunner, commands.StatusActive)
+	err := commands.StatusSet(fakeRunner, commands.StatusActive, "")
 	if err != nil {
 		t.Fatalf("StatusSet returned an error: %v", err)
 	}


### PR DESCRIPTION
# Description

- Add ability to set the Juju status message
- Add ability to retrieve config options of non-string types (ex. int, bool)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
