### PR TITLE
feat: use central hook context struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,22 +34,20 @@ package main
 import (
 	"os"
 
+	"github.com/gruyaume/goops"
 	"github.com/gruyaume/goops/commands"
-	"github.com/gruyaume/goops/environment"
 )
 
 func main() {
-	hookCommand := &commands.HookCommand{}
-	execEnv := &environment.ExecutionEnvironment{}
-	logger := commands.NewLogger(hookCommand)
-	hookName := environment.JujuHookName(execEnv)
-	logger.Info("Hook name:", hookName)
-	err := commands.StatusSet(hookCommand, commands.StatusActive)
+	hookContext := goops.NewHookContext()
+	hookName := hookContext.Environment.JujuHookName()
+	hookContext.Commands.JujuLog(commands.Info, "Hook name:", hookName)
+	err := hookContext.Commands.StatusSet(commands.StatusActive, "A happy charm")
 	if err != nil {
-		logger.Error("Could not set status:", err.Error())
+		hookContext.Commands.JujuLog(commands.Error, "Could not set status:", err.Error())
 		os.Exit(0)
 	}
-	logger.Info("Status set to active")
+	hookContext.Commands.JujuLog(commands.Info, "Status set to active")
 	os.Exit(0)
 }
 ```

--- a/commands/actions.go
+++ b/commands/actions.go
@@ -11,9 +11,9 @@ const (
 	ActionSetCommand  = "action-set"
 )
 
-func ActionGet(runner CommandRunner, key string) (string, error) {
+func (command Command) ActionGet(key string) (string, error) {
 	args := []string{key, "--format=json"}
-	output, err := runner.Run(ActionGetCommand, args...)
+	output, err := command.Runner.Run(ActionGetCommand, args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to get action parameter: %w", err)
 	}
@@ -25,12 +25,12 @@ func ActionGet(runner CommandRunner, key string) (string, error) {
 	return actionParameter, nil
 }
 
-func ActionFail(runner CommandRunner, message string) error {
+func (command Command) ActionFail(message string) error {
 	args := []string{}
 	if message != "" {
 		args = append(args, message)
 	}
-	_, err := runner.Run(ActionFailCommand, args...)
+	_, err := command.Runner.Run(ActionFailCommand, args...)
 	if err != nil {
 		return fmt.Errorf("failed to fail action: %w", err)
 	}
@@ -38,7 +38,7 @@ func ActionFail(runner CommandRunner, message string) error {
 	return nil
 }
 
-func ActionSet(runner CommandRunner, content map[string]string) error {
+func (command Command) ActionSet(content map[string]string) error {
 	if content == nil {
 		return fmt.Errorf("content cannot be empty")
 	}
@@ -46,7 +46,7 @@ func ActionSet(runner CommandRunner, content map[string]string) error {
 	for key, value := range content {
 		args = append(args, key+"="+value)
 	}
-	_, err := runner.Run(ActionSetCommand, args...)
+	_, err := command.Runner.Run(ActionSetCommand, args...)
 	if err != nil {
 		return fmt.Errorf("failed to set action parameters: %w", err)
 	}

--- a/commands/actions_test.go
+++ b/commands/actions_test.go
@@ -11,8 +11,10 @@ func TestActionGet_Success(t *testing.T) {
 		Output: []byte(`"banana"`),
 		Err:    nil,
 	}
-
-	result, err := commands.ActionGet(fakeRunner, "fruit")
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+	result, err := command.ActionGet("fruit")
 	if err != nil {
 		t.Fatalf("ActionGet returned an error: %v", err)
 	}
@@ -40,8 +42,10 @@ func TestActionFail_Success(t *testing.T) {
 		Output: []byte(``),
 		Err:    nil,
 	}
-
-	err := commands.ActionFail(fakeRunner, "my failure message")
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+	err := command.ActionFail("my failure message")
 	if err != nil {
 		t.Fatalf("ActionFail returned an error: %v", err)
 	}
@@ -61,11 +65,14 @@ func TestActionSet_Success(t *testing.T) {
 		Output: []byte(``),
 		Err:    nil,
 	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
 	actionSetValues := map[string]string{
 		"fruit": "banana",
 		"color": "yellow",
 	}
-	err := commands.ActionSet(fakeRunner, actionSetValues)
+	err := command.ActionSet(actionSetValues)
 	if err != nil {
 		t.Fatalf("ActionSet returned an error: %v", err)
 	}

--- a/commands/config.go
+++ b/commands/config.go
@@ -12,9 +12,9 @@ const (
 
 var ErrConfigNotSet = errors.New("config option not set")
 
-func ConfigGet(runner CommandRunner, key string) (any, error) {
+func (command Command) ConfigGet(key string) (any, error) {
 	args := []string{key, "--format=json"}
-	output, err := runner.Run(ConfigGetCommand, args...)
+	output, err := command.Runner.Run(ConfigGetCommand, args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to get config: %w", err)
 	}
@@ -26,8 +26,8 @@ func ConfigGet(runner CommandRunner, key string) (any, error) {
 	return configValue, nil
 }
 
-func ConfigGetString(runner CommandRunner, key string) (string, error) {
-	value, err := ConfigGet(runner, key)
+func (command Command) ConfigGetString(key string) (string, error) {
+	value, err := command.ConfigGet(key)
 	if err != nil {
 		return "", err
 	}
@@ -41,8 +41,8 @@ func ConfigGetString(runner CommandRunner, key string) (string, error) {
 	return strValue, nil
 }
 
-func ConfigGetInt(runner CommandRunner, key string) (int, error) {
-	value, err := ConfigGet(runner, key)
+func (command Command) ConfigGetInt(key string) (int, error) {
+	value, err := command.ConfigGet(key)
 	if err != nil {
 		return 0, err
 	}
@@ -56,8 +56,8 @@ func ConfigGetInt(runner CommandRunner, key string) (int, error) {
 	return int(floatValue), nil
 }
 
-func ConfigGetBool(runner CommandRunner, key string) (bool, error) {
-	value, err := ConfigGet(runner, key)
+func (command Command) ConfigGetBool(key string) (bool, error) {
+	value, err := command.ConfigGet(key)
 	if err != nil {
 		return false, err
 	}

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -11,8 +11,10 @@ func TestConfigGet_Success(t *testing.T) {
 		Output: []byte(`"banana"`),
 		Err:    nil,
 	}
-
-	result, err := commands.ConfigGet(fakeRunner, "fruit")
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+	result, err := command.ConfigGet("fruit")
 	if err != nil {
 		t.Fatalf("ConfigGet returned an error: %v", err)
 	}
@@ -44,7 +46,10 @@ func TestConfigGetString_Success(t *testing.T) {
 		Output: []byte(`"banana"`),
 		Err:    nil,
 	}
-	result, err := commands.ConfigGetString(fakeRunner, "fruit")
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+	result, err := command.ConfigGetString("fruit")
 	if err != nil {
 		t.Fatalf("ConfigGetString returned an error: %v", err)
 	}
@@ -59,7 +64,10 @@ func TestConfigGetString_BadType(t *testing.T) {
 		Output: []byte(`123`),
 		Err:    nil,
 	}
-	_, err := commands.ConfigGetString(fakeRunner, "fruit")
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+	_, err := command.ConfigGetString("fruit")
 	if err == nil {
 		t.Fatalf("Expected error, got nil")
 	}
@@ -73,7 +81,10 @@ func TestConfigGetInt_Success(t *testing.T) {
 		Output: []byte(`123`),
 		Err:    nil,
 	}
-	result, err := commands.ConfigGetInt(fakeRunner, "fruit")
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+	result, err := command.ConfigGetInt("fruit")
 	if err != nil {
 		t.Fatalf("ConfigGetInt returned an error: %v", err)
 	}
@@ -87,7 +98,10 @@ func TestConfigGetInt_BadType(t *testing.T) {
 		Output: []byte(`"banana"`),
 		Err:    nil,
 	}
-	_, err := commands.ConfigGetInt(fakeRunner, "fruit")
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+	_, err := command.ConfigGetInt("fruit")
 	if err == nil {
 		t.Fatalf("Expected error, got nil")
 	}
@@ -101,7 +115,10 @@ func TestConfigGetBool_Success(t *testing.T) {
 		Output: []byte(`true`),
 		Err:    nil,
 	}
-	result, err := commands.ConfigGetBool(fakeRunner, "fruit")
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+	result, err := command.ConfigGetBool("fruit")
 	if err != nil {
 		t.Fatalf("ConfigGetBool returned an error: %v", err)
 	}
@@ -115,7 +132,10 @@ func TestConfigGetBool_BadType(t *testing.T) {
 		Output: []byte(`123`),
 		Err:    nil,
 	}
-	_, err := commands.ConfigGetBool(fakeRunner, "fruit")
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+	_, err := command.ConfigGetBool("fruit")
 	if err == nil {
 		t.Fatalf("Expected error, got nil")
 	}

--- a/commands/exec.go
+++ b/commands/exec.go
@@ -6,10 +6,13 @@ import (
 	"os/exec"
 )
 
+// CommandRunner is an interface for running commands.
+// It allows for mocking in tests.
 type CommandRunner interface {
 	Run(name string, args ...string) ([]byte, error)
 }
 
+// HookCommand is the default implementation of CommandRunner using os/exec.
 type HookCommand struct{}
 
 func (r *HookCommand) Run(name string, args ...string) ([]byte, error) {
@@ -21,4 +24,8 @@ func (r *HookCommand) Run(name string, args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("command %s failed: %s: %w", name, stderr.String(), err)
 	}
 	return output, nil
+}
+
+type Command struct {
+	Runner CommandRunner
 }

--- a/commands/leader.go
+++ b/commands/leader.go
@@ -9,9 +9,9 @@ const (
 	IsLeaderCommand = "is-leader"
 )
 
-func IsLeader(runner CommandRunner) (bool, error) {
+func (command Command) IsLeader() (bool, error) {
 	args := []string{"--format=json"}
-	output, err := runner.Run(IsLeaderCommand, args...)
+	output, err := command.Runner.Run(IsLeaderCommand, args...)
 	if err != nil {
 		return false, fmt.Errorf("failed to verify if unit is leader: %w", err)
 	}

--- a/commands/leader_test.go
+++ b/commands/leader_test.go
@@ -11,8 +11,11 @@ func TestIsLeader_Success(t *testing.T) {
 		Output: []byte(`true`),
 		Err:    nil,
 	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
 
-	result, err := commands.IsLeader(fakeRunner)
+	result, err := command.IsLeader()
 	if err != nil {
 		t.Fatalf("IsLeader returned an error: %v", err)
 	}

--- a/commands/logging.go
+++ b/commands/logging.go
@@ -22,35 +22,11 @@ var levelStrings = []string{
 	"ERROR",
 }
 
-func JujuLog(runner CommandRunner, message string, logLevel Level, extraArgs ...string) {
+func (command Command) JujuLog(logLevel Level, message string, extraArgs ...string) {
 	args := []string{"--log-level=" + levelStrings[logLevel], message}
 	args = append(args, extraArgs...)
-	_, err := runner.Run(JujuLogCommand, args...)
+	_, err := command.Runner.Run(JujuLogCommand, args...)
 	if err != nil {
 		log.Println("failed to run juju-log command:", err)
 	}
-}
-
-type Logger struct {
-	runner CommandRunner
-}
-
-func NewLogger(runner CommandRunner) *Logger {
-	return &Logger{runner: runner}
-}
-
-func (l *Logger) Debug(message string, extraArgs ...string) {
-	JujuLog(l.runner, message, Debug, extraArgs...)
-}
-
-func (l *Logger) Info(message string, extraArgs ...string) {
-	JujuLog(l.runner, message, Info, extraArgs...)
-}
-
-func (l *Logger) Warning(message string, extraArgs ...string) {
-	JujuLog(l.runner, message, Warning, extraArgs...)
-}
-
-func (l *Logger) Error(message string, extraArgs ...string) {
-	JujuLog(l.runner, message, Error, extraArgs...)
 }

--- a/commands/logging_test.go
+++ b/commands/logging_test.go
@@ -11,8 +11,11 @@ func TestJujuLogStatusSet_Success(t *testing.T) {
 		Output: nil,
 		Err:    nil,
 	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
 
-	commands.JujuLog(fakeRunner, "my message", commands.Debug)
+	command.JujuLog(commands.Debug, "my message")
 
 	if fakeRunner.Command != commands.JujuLogCommand {
 		t.Errorf("Expected command %q, got %q", commands.JujuLogCommand, fakeRunner.Command)

--- a/commands/relations.go
+++ b/commands/relations.go
@@ -12,9 +12,9 @@ const (
 	RelationSetCommand  = "relation-set"
 )
 
-func RelationIDs(runner CommandRunner, name string) ([]string, error) {
+func (command Command) RelationIDs(name string) ([]string, error) {
 	args := []string{name, "--format=json"}
-	output, err := runner.Run(RelationIDsCommand, args...)
+	output, err := command.Runner.Run(RelationIDsCommand, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get relation IDs: %w", err)
 	}
@@ -26,7 +26,7 @@ func RelationIDs(runner CommandRunner, name string) ([]string, error) {
 	return relationIDs, nil
 }
 
-func RelationGet(runner CommandRunner, id string, unitID string, app bool) (map[string]string, error) {
+func (command Command) RelationGet(id string, unitID string, app bool) (map[string]string, error) {
 	if id == "" {
 		return nil, fmt.Errorf("relation ID is empty")
 	}
@@ -38,7 +38,7 @@ func RelationGet(runner CommandRunner, id string, unitID string, app bool) (map[
 		args = append(args, "--app")
 	}
 	args = append(args, "--format=json")
-	output, err := runner.Run(RelationGetCommand, args...)
+	output, err := command.Runner.Run(RelationGetCommand, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get relation data: %w", err)
 	}
@@ -50,12 +50,12 @@ func RelationGet(runner CommandRunner, id string, unitID string, app bool) (map[
 	return relationContent, nil
 }
 
-func RelationList(runner CommandRunner, id string) ([]string, error) {
+func (command Command) RelationList(id string) ([]string, error) {
 	if id == "" {
 		return nil, fmt.Errorf("relation ID is empty")
 	}
 	args := []string{"-r=" + id, "--format=json"}
-	output, err := runner.Run(RelationListCommand, args...)
+	output, err := command.Runner.Run(RelationListCommand, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list relation data: %w", err)
 	}
@@ -67,7 +67,7 @@ func RelationList(runner CommandRunner, id string) ([]string, error) {
 	return relationList, nil
 }
 
-func RelationSet(runner CommandRunner, id string, app bool, data map[string]string) error {
+func (command Command) RelationSet(id string, app bool, data map[string]string) error {
 	if id == "" {
 		return fmt.Errorf("relation ID is empty")
 	}
@@ -78,7 +78,7 @@ func RelationSet(runner CommandRunner, id string, app bool, data map[string]stri
 	for key, value := range data {
 		args = append(args, key+"="+value)
 	}
-	output, err := runner.Run(RelationSetCommand, args...)
+	output, err := command.Runner.Run(RelationSetCommand, args...)
 	if err != nil {
 		return fmt.Errorf("failed to set relation data: %w", err)
 	}

--- a/commands/relations_test.go
+++ b/commands/relations_test.go
@@ -11,8 +11,11 @@ func TestRelationIDs_Success(t *testing.T) {
 		Output: []byte(`["123", "456"]`),
 		Err:    nil,
 	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
 
-	result, err := commands.RelationIDs(fakeRunner, "tls-certificates")
+	result, err := command.RelationIDs("tls-certificates")
 	if err != nil {
 		t.Fatalf("RelationIDs returned an error: %v", err)
 	}
@@ -48,8 +51,11 @@ func TestRelationGet_Success(t *testing.T) {
 		Output: []byte(`{"username":"user1","password":"pass1"}`),
 		Err:    nil,
 	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
 
-	result, err := commands.RelationGet(fakeRunner, "certificates:0", "tls-certificates-requirer/0", false)
+	result, err := command.RelationGet("certificates:0", "tls-certificates-requirer/0", false)
 	if err != nil {
 		t.Fatalf("RelationGet returned an error: %v", err)
 	}
@@ -91,8 +97,10 @@ func TestRelationList_Success(t *testing.T) {
 		Output: []byte(`["tls-certificates-requirer/0", "tls-certificates-requirer/1"]`),
 		Err:    nil,
 	}
-
-	result, err := commands.RelationList(fakeRunner, "certificates:0")
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+	result, err := command.RelationList("certificates:0")
 	if err != nil {
 		t.Fatalf("RelationList returned an error: %v", err)
 	}
@@ -122,8 +130,11 @@ func TestRelationSet_Success(t *testing.T) {
 		Output: nil,
 		Err:    nil,
 	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
 
-	err := commands.RelationSet(fakeRunner, "certificates:0", true, map[string]string{"username": "user1", "password": "pass1"})
+	err := command.RelationSet("certificates:0", true, map[string]string{"username": "user1", "password": "pass1"})
 	if err != nil {
 		t.Fatalf("RelationSet returned an error: %v", err)
 	}

--- a/commands/secrets.go
+++ b/commands/secrets.go
@@ -11,8 +11,8 @@ const (
 	SecretAddCommand = "secret-add"
 )
 
-func SecretIDs(runner CommandRunner) ([]string, error) {
-	output, err := runner.Run(SecredIDsCommand, "--format=json")
+func (command Command) SecretIDs() ([]string, error) {
+	output, err := command.Runner.Run(SecredIDsCommand, "--format=json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret IDs: %w", err)
 	}
@@ -24,7 +24,7 @@ func SecretIDs(runner CommandRunner) ([]string, error) {
 	return secretIDs, nil
 }
 
-func SecretGet(runner CommandRunner, id string, label string, peek bool, refresh bool) (map[string]string, error) {
+func (command Command) SecretGet(id string, label string, peek bool, refresh bool) (map[string]string, error) {
 	var args []string
 	if id != "" {
 		args = append(args, id)
@@ -39,7 +39,7 @@ func SecretGet(runner CommandRunner, id string, label string, peek bool, refresh
 		args = append(args, "--refresh")
 	}
 	args = append(args, "--format=json")
-	output, err := runner.Run(SecretGetCommand, args...)
+	output, err := command.Runner.Run(SecretGetCommand, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret: %w", err)
 	}
@@ -51,7 +51,7 @@ func SecretGet(runner CommandRunner, id string, label string, peek bool, refresh
 	return secretContent, nil
 }
 
-func SecretAdd(runner CommandRunner, content map[string]string, description string, label string) (string, error) {
+func (command Command) SecretAdd(content map[string]string, description string, label string) (string, error) {
 	if len(content) == 0 {
 		return "", fmt.Errorf("content cannot be empty")
 	}
@@ -65,7 +65,7 @@ func SecretAdd(runner CommandRunner, content map[string]string, description stri
 	if label != "" {
 		args = append(args, "--label="+label)
 	}
-	output, err := runner.Run(SecretAddCommand, args...)
+	output, err := command.Runner.Run(SecretAddCommand, args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to add secret: %w", err)
 	}

--- a/commands/secrets_test.go
+++ b/commands/secrets_test.go
@@ -11,8 +11,11 @@ func TestSecretIDs_Success(t *testing.T) {
 		Output: []byte(`["123", "456"]`),
 		Err:    nil,
 	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
 
-	result, err := commands.SecretIDs(fakeRunner)
+	result, err := command.SecretIDs()
 	if err != nil {
 		t.Fatalf("SecretIDs returned an error: %v", err)
 	}
@@ -45,8 +48,11 @@ func TestSecretGet_Success(t *testing.T) {
 		Output: []byte(`{"username":"user1","password":"pass1"}`),
 		Err:    nil,
 	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
 
-	result, err := commands.SecretGet(fakeRunner, "123", "my-label", false, true)
+	result, err := command.SecretGet("123", "my-label", false, true)
 	if err != nil {
 		t.Fatalf("SecretGet returned an error: %v", err)
 	}
@@ -101,8 +107,11 @@ func TestSecretAdd_Success(t *testing.T) {
 		Output: []byte(`{"result":"success"}`),
 		Err:    nil,
 	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
 
-	result, err := commands.SecretAdd(fakeRunner, content, description, label)
+	result, err := command.SecretAdd(content, description, label)
 	if err != nil {
 		t.Fatalf("SecretAdd returned an error: %v", err)
 	}
@@ -144,8 +153,11 @@ func TestSecretAdd_EmptyContent(t *testing.T) {
 		Output: []byte(""),
 		Err:    nil,
 	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
 
-	_, err := commands.SecretAdd(fakeRunner, map[string]string{}, "desc", "label")
+	_, err := command.SecretAdd(map[string]string{}, "desc", "label")
 	if err == nil {
 		t.Error("Expected error when content is empty, but got nil")
 	}

--- a/commands/status.go
+++ b/commands/status.go
@@ -16,13 +16,13 @@ const (
 	StatusSetCommand = "status-set"
 )
 
-func StatusSet(runner CommandRunner, status Status, message string) error {
+func (command Command) StatusSet(status Status, message string) error {
 	var args []string
 	args = append(args, string(status))
 	if message != "" {
 		args = append(args, message)
 	}
-	_, err := runner.Run(StatusSetCommand, args...)
+	_, err := command.Runner.Run(StatusSetCommand, args...)
 	if err != nil {
 		return fmt.Errorf("failed to set status: %w", err)
 	}

--- a/commands/status_test.go
+++ b/commands/status_test.go
@@ -11,8 +11,11 @@ func TestStatusSet_Success(t *testing.T) {
 		Output: nil,
 		Err:    nil,
 	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
 
-	err := commands.StatusSet(fakeRunner, commands.StatusActive, "")
+	err := command.StatusSet(commands.StatusActive, "")
 	if err != nil {
 		t.Fatalf("StatusSet returned an error: %v", err)
 	}

--- a/context.go
+++ b/context.go
@@ -1,0 +1,20 @@
+package goops
+
+import (
+	"github.com/gruyaume/goops/commands"
+	"github.com/gruyaume/goops/environment"
+)
+
+type HookContext struct {
+	Commands    *commands.Command
+	Environment *environment.Environment
+}
+
+func NewHookContext() HookContext {
+	hookCommand := &commands.Command{}
+	environment := &environment.Environment{}
+	return HookContext{
+		Commands:    hookCommand,
+		Environment: environment,
+	}
+}

--- a/environment/get_env.go
+++ b/environment/get_env.go
@@ -11,3 +11,7 @@ type ExecutionEnvironment struct{}
 func (r *ExecutionEnvironment) Get(name string) string {
 	return os.Getenv(name)
 }
+
+type Environment struct {
+	Getter EnvironmentGetter
+}

--- a/environment/juju_action_name.go
+++ b/environment/juju_action_name.go
@@ -2,6 +2,6 @@ package environment
 
 const JujuActionNameEnvVar = "JUJU_ACTION_NAME"
 
-func JujuActionName(getter EnvironmentGetter) string {
-	return getter.Get(JujuActionNameEnvVar)
+func (env Environment) JujuActionName() string {
+	return env.Getter.Get(JujuActionNameEnvVar)
 }

--- a/environment/juju_hook_name.go
+++ b/environment/juju_hook_name.go
@@ -2,6 +2,6 @@ package environment
 
 const JujuHookNameEnvVar = "JUJU_HOOK_NAME"
 
-func JujuHookName(getter EnvironmentGetter) string {
-	return getter.Get(JujuHookNameEnvVar)
+func (env Environment) JujuHookName() string {
+	return env.Getter.Get(JujuHookNameEnvVar)
 }

--- a/environment/juju_version.go
+++ b/environment/juju_version.go
@@ -2,6 +2,6 @@ package environment
 
 const JujuVersionEnvVar = "JUJU_VERSION"
 
-func JujuVersion(getter EnvironmentGetter) string {
-	return getter.Get(JujuVersionEnvVar)
+func (env Environment) JujuVersion() string {
+	return env.Getter.Get(JujuVersionEnvVar)
 }

--- a/example/charm.go
+++ b/example/charm.go
@@ -1,0 +1,21 @@
+package example
+
+import (
+	"os"
+
+	"github.com/gruyaume/goops"
+	"github.com/gruyaume/goops/commands"
+)
+
+func Main() {
+	hookContext := goops.NewHookContext()
+	hookName := hookContext.Environment.JujuHookName()
+	hookContext.Commands.JujuLog(commands.Info, "Hook name:", hookName)
+	err := hookContext.Commands.StatusSet(commands.StatusActive, "A happy charm")
+	if err != nil {
+		hookContext.Commands.JujuLog(commands.Error, "Could not set status:", err.Error())
+		os.Exit(0)
+	}
+	hookContext.Commands.JujuLog(commands.Info, "Status set to active")
+	os.Exit(0)
+}


### PR DESCRIPTION
# Description

Allow charm authors to interact with Juju via a single `HookContext`:

```go
package main

import (
	"os"

	"github.com/gruyaume/goops"
	"github.com/gruyaume/goops/commands"
)

func main() {
	hookContext := goops.NewHookContext()
	hookName := hookContext.Environment.JujuHookName()
	hookContext.Commands.JujuLog(commands.Info, "Hook name:", hookName)
	err := hookContext.Commands.StatusSet(commands.StatusActive, "A happy charm")
	if err != nil {
		hookContext.Commands.JujuLog(commands.Error, "Could not set status:", err.Error())
		os.Exit(0)
	}
	hookContext.Commands.JujuLog(commands.Info, "Status set to active")
	os.Exit(0)
}
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
