### PR TITLE
feat: add remaining juju commands and use parameter objects

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 Guillaume Bélanger
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ func main() {
 	hookName := hookContext.Environment.JujuHookName()
 	hookContext.Commands.JujuLog(commands.Info, "Hook name:", hookName)
 
-	err := hookContext.Commands.StatusSet(commands.StatusActive, "A happy charm")
+	statusOpts := &commands.StatusOptions{
+		Name:    commands.StatusActive,
+		Message: "A happy charm",
+	}
+
+	err := hookContext.Commands.StatusSet(statusOpts)
 	if err != nil {
 		hookContext.Commands.JujuLog(commands.Error, "Could not set status:", err.Error())
 		os.Exit(0)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 `goops` is a Go library for developing robust Juju charms. While charm developers traditionally use the [ops Python framework](https://github.com/canonical/operator), Python's dynamic typing and interpreter-based execution often lead to runtime errors and portability issues across different bases. In contrast, Go compiles to a single, self-contained binary, ensuring greater reliability and consistent behavior in any environment.
 
-## Try it now
+## Tutorial
 
 ### 1. Use the Charmcraft `go` plugin
 
@@ -61,7 +61,13 @@ func main() {
 
 You can find an example of the library being used in the [certificates charm repository](https://github.com/gruyaume/certificates-operator). 
 
-## Design principles
+## Reference
+
+### Design principles
 
 - **Reliability**: Building predictable, robust charms is our top priority.
 - **Simplicity**: `goops` serves as a minimal, one-to-one mapping between Juju concepts and Go constructs. It is not a framework; it does not impose charm design patterns. The library has no dependencies.
+
+### Juju compatibility
+
+`goops` is compatible with Juju 3.6 and later.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 `goops` is a Go library for developing robust Juju charms. While charm developers traditionally use the [ops Python framework](https://github.com/canonical/operator), Python's dynamic typing and interpreter-based execution often lead to runtime errors and portability issues across different bases. In contrast, Go compiles to a single, self-contained binary, ensuring greater reliability and consistent behavior in any environment.
 
-## Tutorial
+## Getting Started
 
 ### 1. Use the Charmcraft `go` plugin
 

--- a/commands/actions.go
+++ b/commands/actions.go
@@ -12,10 +12,26 @@ const (
 	actionSetCommand  = "action-set"
 )
 
-func (command Command) ActionFail(message string) error {
+type ActionFailOptions struct {
+	Message string
+}
+
+type ActionGetOptions struct {
+	Key string
+}
+
+type ActionLogOptions struct {
+	Message string
+}
+
+type ActionSetOptions struct {
+	Content map[string]string
+}
+
+func (command Command) ActionFail(opts *ActionFailOptions) error {
 	args := []string{}
-	if message != "" {
-		args = append(args, message)
+	if opts.Message != "" {
+		args = append(args, opts.Message)
 	}
 
 	_, err := command.Runner.Run(actionFailCommand, args...)
@@ -26,8 +42,8 @@ func (command Command) ActionFail(message string) error {
 	return nil
 }
 
-func (command Command) ActionGet(key string) (string, error) {
-	args := []string{key, "--format=json"}
+func (command Command) ActionGet(opts *ActionGetOptions) (string, error) {
+	args := []string{opts.Key, "--format=json"}
 
 	output, err := command.Runner.Run(actionGetCommand, args...)
 	if err != nil {
@@ -44,12 +60,12 @@ func (command Command) ActionGet(key string) (string, error) {
 	return actionParameter, nil
 }
 
-func (command Command) ActionLog(message string) error {
-	if message == "" {
+func (command Command) ActionLog(opts *ActionLogOptions) error {
+	if opts.Message == "" {
 		return fmt.Errorf("message cannot be empty")
 	}
 
-	args := []string{message}
+	args := []string{opts.Message}
 
 	_, err := command.Runner.Run(actionLogCommand, args...)
 	if err != nil {
@@ -59,13 +75,13 @@ func (command Command) ActionLog(message string) error {
 	return nil
 }
 
-func (command Command) ActionSet(content map[string]string) error {
-	if content == nil {
+func (command Command) ActionSet(opts *ActionSetOptions) error {
+	if opts.Content == nil {
 		return fmt.Errorf("content cannot be empty")
 	}
 
 	var args []string
-	for key, value := range content {
+	for key, value := range opts.Content {
 		args = append(args, key+"="+value)
 	}
 

--- a/commands/actions_test.go
+++ b/commands/actions_test.go
@@ -15,7 +15,11 @@ func TestActionFail_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	err := command.ActionFail("my failure message")
+	actionFailOptions := &commands.ActionFailOptions{
+		Message: "my failure message",
+	}
+
+	err := command.ActionFail(actionFailOptions)
 	if err != nil {
 		t.Fatalf("ActionFail returned an error: %v", err)
 	}
@@ -42,7 +46,11 @@ func TestActionGet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.ActionGet("fruit")
+	actionGetOptions := &commands.ActionGetOptions{
+		Key: "fruit",
+	}
+
+	result, err := command.ActionGet(actionGetOptions)
 	if err != nil {
 		t.Fatalf("ActionGet returned an error: %v", err)
 	}
@@ -77,7 +85,11 @@ func TestActionLog_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	err := command.ActionLog("my log message")
+	actionLogOptions := &commands.ActionLogOptions{
+		Message: "my log message",
+	}
+
+	err := command.ActionLog(actionLogOptions)
 	if err != nil {
 		t.Fatalf("ActionLog returned an error: %v", err)
 	}
@@ -108,7 +120,11 @@ func TestActionSet_Success(t *testing.T) {
 		"color": "yellow",
 	}
 
-	err := command.ActionSet(actionSetValues)
+	actionSetOptions := &commands.ActionSetOptions{
+		Content: actionSetValues,
+	}
+
+	err := command.ActionSet(actionSetOptions)
 	if err != nil {
 		t.Fatalf("ActionSet returned an error: %v", err)
 	}

--- a/commands/application_version.go
+++ b/commands/application_version.go
@@ -8,10 +8,14 @@ const (
 	applicationVersionSetCommand = "application-version-set"
 )
 
-func (command Command) ApplicationVersionSet(message string) error {
+type ApplicationVersionSetOptions struct {
+	Version string
+}
+
+func (command Command) ApplicationVersionSet(opts *ApplicationVersionSetOptions) error {
 	args := []string{}
-	if message != "" {
-		args = append(args, message)
+	if opts.Version != "" {
+		args = append(args, opts.Version)
 	}
 
 	_, err := command.Runner.Run(applicationVersionSetCommand, args...)

--- a/commands/application_version_test.go
+++ b/commands/application_version_test.go
@@ -15,8 +15,11 @@ func TestApplicationVersionSet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 	version := "1.2.3"
+	applicationVersionSetOptions := &commands.ApplicationVersionSetOptions{
+		Version: version,
+	}
 
-	err := command.ApplicationVersionSet(version)
+	err := command.ApplicationVersionSet(applicationVersionSetOptions)
 	if err != nil {
 		t.Fatalf("ApplicationVersionSet returned an error: %v", err)
 	}

--- a/commands/config.go
+++ b/commands/config.go
@@ -12,8 +12,12 @@ const (
 
 var ErrConfigNotSet = errors.New("config option not set")
 
-func (command Command) ConfigGet(key string) (any, error) {
-	args := []string{key, "--format=json"}
+type ConfigGetOptions struct {
+	Key string
+}
+
+func (command Command) ConfigGet(opts *ConfigGetOptions) (any, error) {
+	args := []string{opts.Key, "--format=json"}
 
 	output, err := command.Runner.Run(configGetCommand, args...)
 	if err != nil {
@@ -30,8 +34,8 @@ func (command Command) ConfigGet(key string) (any, error) {
 	return configValue, nil
 }
 
-func (command Command) ConfigGetString(key string) (string, error) {
-	value, err := command.ConfigGet(key)
+func (command Command) ConfigGetString(opts *ConfigGetOptions) (string, error) {
+	value, err := command.ConfigGet(opts)
 	if err != nil {
 		return "", err
 	}
@@ -48,8 +52,8 @@ func (command Command) ConfigGetString(key string) (string, error) {
 	return strValue, nil
 }
 
-func (command Command) ConfigGetInt(key string) (int, error) {
-	value, err := command.ConfigGet(key)
+func (command Command) ConfigGetInt(opts *ConfigGetOptions) (int, error) {
+	value, err := command.ConfigGet(opts)
 	if err != nil {
 		return 0, err
 	}
@@ -66,8 +70,8 @@ func (command Command) ConfigGetInt(key string) (int, error) {
 	return int(floatValue), nil
 }
 
-func (command Command) ConfigGetBool(key string) (bool, error) {
-	value, err := command.ConfigGet(key)
+func (command Command) ConfigGetBool(opts *ConfigGetOptions) (bool, error) {
+	value, err := command.ConfigGet(opts)
 	if err != nil {
 		return false, err
 	}

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -15,7 +15,11 @@ func TestConfigGet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.ConfigGet("fruit")
+	configGetOptions := &commands.ConfigGetOptions{
+		Key: "fruit",
+	}
+
+	result, err := command.ConfigGet(configGetOptions)
 	if err != nil {
 		t.Fatalf("ConfigGet returned an error: %v", err)
 	}
@@ -54,7 +58,11 @@ func TestConfigGetString_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.ConfigGetString("fruit")
+	configGetOptions := &commands.ConfigGetOptions{
+		Key: "fruit",
+	}
+
+	result, err := command.ConfigGetString(configGetOptions)
 	if err != nil {
 		t.Fatalf("ConfigGetString returned an error: %v", err)
 	}
@@ -73,7 +81,11 @@ func TestConfigGetString_BadType(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	_, err := command.ConfigGetString("fruit")
+	configGetOptions := &commands.ConfigGetOptions{
+		Key: "fruit",
+	}
+
+	_, err := command.ConfigGetString(configGetOptions)
 	if err == nil {
 		t.Fatalf("Expected error, got nil")
 	}
@@ -92,7 +104,11 @@ func TestConfigGetInt_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.ConfigGetInt("fruit")
+	configGetOptions := &commands.ConfigGetOptions{
+		Key: "fruit",
+	}
+
+	result, err := command.ConfigGetInt(configGetOptions)
 	if err != nil {
 		t.Fatalf("ConfigGetInt returned an error: %v", err)
 	}
@@ -111,7 +127,11 @@ func TestConfigGetInt_BadType(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	_, err := command.ConfigGetInt("fruit")
+	configGetOptions := &commands.ConfigGetOptions{
+		Key: "fruit",
+	}
+
+	_, err := command.ConfigGetInt(configGetOptions)
 	if err == nil {
 		t.Fatalf("Expected error, got nil")
 	}
@@ -130,7 +150,11 @@ func TestConfigGetBool_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.ConfigGetBool("fruit")
+	configGetOptions := &commands.ConfigGetOptions{
+		Key: "fruit",
+	}
+
+	result, err := command.ConfigGetBool(configGetOptions)
 	if err != nil {
 		t.Fatalf("ConfigGetBool returned an error: %v", err)
 	}
@@ -149,7 +173,11 @@ func TestConfigGetBool_BadType(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	_, err := command.ConfigGetBool("fruit")
+	configGetOptions := &commands.ConfigGetOptions{
+		Key: "fruit",
+	}
+
+	_, err := command.ConfigGetBool(configGetOptions)
 	if err == nil {
 		t.Fatalf("Expected error, got nil")
 	}

--- a/commands/juju_reboot.go
+++ b/commands/juju_reboot.go
@@ -4,9 +4,13 @@ const (
 	jujuRebootCommand = "juju-reboot"
 )
 
-func (command Command) JujuReboot(now bool) error {
+type JujuRebootOptions struct {
+	Now bool
+}
+
+func (command Command) JujuReboot(opts *JujuRebootOptions) error {
 	var args []string
-	if now {
+	if opts.Now {
 		args = append(args, "--now")
 	}
 

--- a/commands/juju_reboot_test.go
+++ b/commands/juju_reboot_test.go
@@ -15,7 +15,11 @@ func TestJujuReboot_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	err := command.JujuReboot(true)
+	jujuRebootOptions := &commands.JujuRebootOptions{
+		Now: true,
+	}
+
+	err := command.JujuReboot(jujuRebootOptions)
 	if err != nil {
 		t.Fatalf("JujuReboot returned an error: %v", err)
 	}

--- a/commands/network.go
+++ b/commands/network.go
@@ -25,34 +25,43 @@ type Network struct {
 	EgressSubnets    []string      `json:"egress-subnets"`
 }
 
-func (command Command) NetworkGet(bindingName string, bindAddress bool, egressSubnets bool, ingressAddress bool, primaryAddress bool, relation string) (*Network, error) {
+type NetworkGetOptions struct {
+	BindingName    string
+	BindAddress    bool
+	EgressSubnets  bool
+	IngressAddress bool
+	PrimaryAddress bool
+	Relation       string
+}
+
+func (command Command) NetworkGet(opts *NetworkGetOptions) (*Network, error) {
 	var args []string
 
-	if bindingName == "" {
+	if opts.BindingName == "" {
 		return nil, fmt.Errorf("binding name cannot be empty")
 	}
 
-	if bindAddress {
+	if opts.BindAddress {
 		args = append(args, "--bind-address")
 	}
 
-	if egressSubnets {
+	if opts.EgressSubnets {
 		args = append(args, "--egress-subnets")
 	}
 
-	if ingressAddress {
+	if opts.IngressAddress {
 		args = append(args, "--ingress-address")
 	}
 
-	if primaryAddress {
+	if opts.PrimaryAddress {
 		args = append(args, "--primary-address")
 	}
 
-	if relation != "" {
-		args = append(args, "--relation="+relation)
+	if opts.Relation != "" {
+		args = append(args, "--relation="+opts.Relation)
 	}
 
-	args = append(args, bindingName, "--format=json")
+	args = append(args, opts.BindingName, "--format=json")
 
 	output, err := command.Runner.Run(networkGetCommand, args...)
 	if err != nil {

--- a/commands/network_test.go
+++ b/commands/network_test.go
@@ -15,7 +15,11 @@ func TestNetworkGet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.NetworkGet("whatever", false, false, false, false, "")
+	networkGetOptions := &commands.NetworkGetOptions{
+		BindingName: "whatever",
+	}
+
+	result, err := command.NetworkGet(networkGetOptions)
 	if err != nil {
 		t.Fatalf("NetworkGet returned an error: %v", err)
 	}

--- a/commands/ports.go
+++ b/commands/ports.go
@@ -16,20 +16,34 @@ type Port struct {
 	Protocol string // allowed values: tcp, udp
 }
 
-func (command Command) SetPorts(ports []Port) error {
+type SetPortOptions struct {
+	Ports []*Port
+}
+
+type OpenPortOptions struct {
+	Port     int
+	Protocol string // allowed values: tcp, udp
+}
+
+type ClosePortOptions struct {
+	Port     int
+	Protocol string // allowed values: tcp, udp
+}
+
+func (command Command) SetPorts(opts *SetPortOptions) error {
 	openedPorts, err := command.OpenedPorts()
 	if err != nil {
 		return fmt.Errorf("failed to get opened ports: %w", err)
 	}
 
-	desiredMap := make(map[string]Port)
+	desiredMap := make(map[string]*Port)
 
-	for _, port := range ports {
+	for _, port := range opts.Ports {
 		key := fmt.Sprintf("%d/%s", port.Port, port.Protocol)
 		desiredMap[key] = port
 	}
 
-	openedMap := make(map[string]Port)
+	openedMap := make(map[string]*Port)
 
 	for _, port := range openedPorts {
 		key := fmt.Sprintf("%d/%s", port.Port, port.Protocol)
@@ -39,7 +53,11 @@ func (command Command) SetPorts(ports []Port) error {
 	// Open ports that are desired but not currently opened.
 	for key, port := range desiredMap {
 		if _, exists := openedMap[key]; !exists {
-			if err := command.OpenPort(port); err != nil {
+			openPortOpts := &OpenPortOptions{
+				Port:     port.Port,
+				Protocol: port.Protocol,
+			}
+			if err := command.OpenPort(openPortOpts); err != nil {
 				return fmt.Errorf("failed to open port %s: %w", key, err)
 			}
 		}
@@ -48,7 +66,11 @@ func (command Command) SetPorts(ports []Port) error {
 	// Close ports that are currently opened but not desired.
 	for key, port := range openedMap {
 		if _, exists := desiredMap[key]; !exists {
-			if err := command.ClosePort(port); err != nil {
+			closePortOpts := &ClosePortOptions{
+				Port:     port.Port,
+				Protocol: port.Protocol,
+			}
+			if err := command.ClosePort(closePortOpts); err != nil {
 				return fmt.Errorf("failed to close port %s: %w", key, err)
 			}
 		}
@@ -57,45 +79,45 @@ func (command Command) SetPorts(ports []Port) error {
 	return nil
 }
 
-func (command Command) OpenPort(port Port) error {
-	if port.Port < 0 || port.Port > 65535 {
-		return fmt.Errorf("port %d is out of range", port.Port)
+func (command Command) OpenPort(opts *OpenPortOptions) error {
+	if opts.Port < 0 || opts.Port > 65535 {
+		return fmt.Errorf("port %d is out of range", opts.Port)
 	}
 
-	if port.Protocol != "tcp" && port.Protocol != "udp" {
-		return fmt.Errorf("protocol %s is not supported", port.Protocol)
+	if opts.Protocol != "tcp" && opts.Protocol != "udp" {
+		return fmt.Errorf("protocol %s is not supported", opts.Protocol)
 	}
 
-	args := []string{fmt.Sprintf("%d/%s", port.Port, port.Protocol)}
+	args := []string{fmt.Sprintf("%d/%s", opts.Port, opts.Protocol)}
 
 	_, err := command.Runner.Run(openPortCommand, args...)
 	if err != nil {
-		return fmt.Errorf("failed to open port %d/%s: %w", port.Port, port.Protocol, err)
+		return fmt.Errorf("failed to open port %d/%s: %w", opts.Port, opts.Protocol, err)
 	}
 
 	return nil
 }
 
-func (command Command) ClosePort(port Port) error {
-	if port.Port < 0 || port.Port > 65535 {
-		return fmt.Errorf("port %d is out of range", port.Port)
+func (command Command) ClosePort(opts *ClosePortOptions) error {
+	if opts.Port < 0 || opts.Port > 65535 {
+		return fmt.Errorf("port %d is out of range", opts.Port)
 	}
 
-	if port.Protocol != "tcp" && port.Protocol != "udp" {
-		return fmt.Errorf("protocol %s is not supported", port.Protocol)
+	if opts.Protocol != "tcp" && opts.Protocol != "udp" {
+		return fmt.Errorf("protocol %s is not supported", opts.Protocol)
 	}
 
-	args := []string{fmt.Sprintf("%d/%s", port.Port, port.Protocol)}
+	args := []string{fmt.Sprintf("%d/%s", opts.Port, opts.Protocol)}
 
 	_, err := command.Runner.Run(closePortCommand, args...)
 	if err != nil {
-		return fmt.Errorf("failed to open port %d/%s: %w", port.Port, port.Protocol, err)
+		return fmt.Errorf("failed to open port %d/%s: %w", opts.Port, opts.Protocol, err)
 	}
 
 	return nil
 }
 
-func (command Command) OpenedPorts() ([]Port, error) {
+func (command Command) OpenedPorts() ([]*Port, error) {
 	args := []string{"--format=json"}
 
 	output, err := command.Runner.Run(openedPortsCommand, args...)
@@ -110,7 +132,7 @@ func (command Command) OpenedPorts() ([]Port, error) {
 		return nil, fmt.Errorf("failed to parse opened ports: %w", err)
 	}
 
-	var openedPorts []Port
+	var openedPorts []*Port
 
 	for _, portString := range openedPortsString {
 		var port Port
@@ -120,7 +142,7 @@ func (command Command) OpenedPorts() ([]Port, error) {
 			return nil, fmt.Errorf("failed to parse port %s: %w", portString, err)
 		}
 
-		openedPorts = append(openedPorts, port)
+		openedPorts = append(openedPorts, &port)
 	}
 
 	return openedPorts, nil

--- a/commands/ports_test.go
+++ b/commands/ports_test.go
@@ -14,7 +14,7 @@ func TestOpenPortTCP_Success(t *testing.T) {
 	command := commands.Command{
 		Runner: fakeRunner,
 	}
-	port := commands.Port{
+	port := &commands.OpenPortOptions{
 		Port:     80,
 		Protocol: "tcp",
 	}
@@ -45,7 +45,7 @@ func TestOpenPortUDP_Success(t *testing.T) {
 	command := commands.Command{
 		Runner: fakeRunner,
 	}
-	port := commands.Port{
+	port := &commands.OpenPortOptions{
 		Port:     80,
 		Protocol: "udp",
 	}
@@ -76,7 +76,7 @@ func TestOpenPortInvalidPort_Failure(t *testing.T) {
 	command := commands.Command{
 		Runner: fakeRunner,
 	}
-	port := commands.Port{
+	port := &commands.OpenPortOptions{
 		Port:     -1,
 		Protocol: "tcp",
 	}
@@ -103,7 +103,7 @@ func TestOpenPortInvalidProtocol_Failure(t *testing.T) {
 	command := commands.Command{
 		Runner: fakeRunner,
 	}
-	port := commands.Port{
+	port := &commands.OpenPortOptions{
 		Port:     80,
 		Protocol: "invalid",
 	}
@@ -130,7 +130,7 @@ func TestClosePortTCP_Success(t *testing.T) {
 	command := commands.Command{
 		Runner: fakeRunner,
 	}
-	port := commands.Port{
+	port := &commands.ClosePortOptions{
 		Port:     80,
 		Protocol: "tcp",
 	}
@@ -161,7 +161,7 @@ func TestClosePortUDP_Success(t *testing.T) {
 	command := commands.Command{
 		Runner: fakeRunner,
 	}
-	port := commands.Port{
+	port := &commands.ClosePortOptions{
 		Port:     80,
 		Protocol: "udp",
 	}
@@ -192,7 +192,7 @@ func TestClosePortInvalidPort_Failure(t *testing.T) {
 	command := commands.Command{
 		Runner: fakeRunner,
 	}
-	port := commands.Port{
+	port := &commands.ClosePortOptions{
 		Port:     -1,
 		Protocol: "tcp",
 	}
@@ -219,7 +219,7 @@ func TestClosePortInvalidProtocol_Failure(t *testing.T) {
 	command := commands.Command{
 		Runner: fakeRunner,
 	}
-	port := commands.Port{
+	port := &commands.ClosePortOptions{
 		Port:     80,
 		Protocol: "invalid",
 	}

--- a/commands/relations.go
+++ b/commands/relations.go
@@ -17,8 +17,32 @@ type RelationModel struct {
 	UUID string `json:"uuid"`
 }
 
-func (command Command) RelationIDs(name string) ([]string, error) {
-	args := []string{name, "--format=json"}
+type RelationIDsOptions struct {
+	Name string
+}
+
+type RelationGetOptions struct {
+	ID     string
+	UnitID string
+	App    bool
+}
+
+type RelationListOptions struct {
+	ID string
+}
+
+type RelationSetOptions struct {
+	ID   string
+	App  bool
+	Data map[string]string
+}
+
+type RelationModelGetOptions struct {
+	ID string
+}
+
+func (command Command) RelationIDs(opts *RelationIDsOptions) ([]string, error) {
+	args := []string{opts.Name, "--format=json"}
 
 	output, err := command.Runner.Run(relationIDsCommand, args...)
 	if err != nil {
@@ -35,17 +59,17 @@ func (command Command) RelationIDs(name string) ([]string, error) {
 	return relationIDs, nil
 }
 
-func (command Command) RelationGet(id string, unitID string, app bool) (map[string]string, error) {
-	if id == "" {
+func (command Command) RelationGet(opts *RelationGetOptions) (map[string]string, error) {
+	if opts.ID == "" {
 		return nil, fmt.Errorf("relation ID is empty")
 	}
 
-	if unitID == "" {
+	if opts.UnitID == "" {
 		return nil, fmt.Errorf("unit ID is empty")
 	}
 
-	args := []string{"-r=" + id, "-", unitID}
-	if app {
+	args := []string{"-r=" + opts.ID, "-", opts.UnitID}
+	if opts.App {
 		args = append(args, "--app")
 	}
 
@@ -66,12 +90,12 @@ func (command Command) RelationGet(id string, unitID string, app bool) (map[stri
 	return relationContent, nil
 }
 
-func (command Command) RelationList(id string) ([]string, error) {
-	if id == "" {
+func (command Command) RelationList(opts *RelationListOptions) ([]string, error) {
+	if opts.ID == "" {
 		return nil, fmt.Errorf("relation ID is empty")
 	}
 
-	args := []string{"-r=" + id, "--format=json"}
+	args := []string{"-r=" + opts.ID, "--format=json"}
 
 	output, err := command.Runner.Run(relationListCommand, args...)
 	if err != nil {
@@ -88,17 +112,17 @@ func (command Command) RelationList(id string) ([]string, error) {
 	return relationList, nil
 }
 
-func (command Command) RelationSet(id string, app bool, data map[string]string) error {
-	if id == "" {
+func (command Command) RelationSet(opts *RelationSetOptions) error {
+	if opts.ID == "" {
 		return fmt.Errorf("relation ID is empty")
 	}
 
-	args := []string{"-r=" + id}
-	if app {
+	args := []string{"-r=" + opts.ID}
+	if opts.App {
 		args = append(args, "--app")
 	}
 
-	for key, value := range data {
+	for key, value := range opts.Data {
 		args = append(args, key+"="+value)
 	}
 
@@ -114,12 +138,12 @@ func (command Command) RelationSet(id string, app bool, data map[string]string) 
 	return nil
 }
 
-func (command Command) RelationModelGet(id string) (*RelationModel, error) {
-	if id == "" {
+func (command Command) RelationModelGet(opts *RelationModelGetOptions) (*RelationModel, error) {
+	if opts.ID == "" {
 		return nil, fmt.Errorf("relation ID is empty")
 	}
 
-	args := []string{"-r=" + id, "--format=json"}
+	args := []string{"-r=" + opts.ID, "--format=json"}
 
 	output, err := command.Runner.Run(relationModelGetCommand, args...)
 	if err != nil {

--- a/commands/relations_test.go
+++ b/commands/relations_test.go
@@ -15,7 +15,11 @@ func TestRelationIDs_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.RelationIDs("tls-certificates")
+	relationIDsOptions := &commands.RelationIDsOptions{
+		Name: "tls-certificates",
+	}
+
+	result, err := command.RelationIDs(relationIDsOptions)
 	if err != nil {
 		t.Fatalf("RelationIDs returned an error: %v", err)
 	}
@@ -60,7 +64,12 @@ func TestRelationGet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.RelationGet("certificates:0", "tls-certificates-requirer/0", false)
+	relationGetOptions := &commands.RelationGetOptions{
+		ID:     "certificates:0",
+		UnitID: "tls-certificates-requirer/0",
+	}
+
+	result, err := command.RelationGet(relationGetOptions)
 	if err != nil {
 		t.Fatalf("RelationGet returned an error: %v", err)
 	}
@@ -113,7 +122,11 @@ func TestRelationList_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.RelationList("certificates:0")
+	relationListOptions := &commands.RelationListOptions{
+		ID: "certificates:0",
+	}
+
+	result, err := command.RelationList(relationListOptions)
 	if err != nil {
 		t.Fatalf("RelationList returned an error: %v", err)
 	}
@@ -154,7 +167,16 @@ func TestRelationSet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	err := command.RelationSet("certificates:0", true, map[string]string{"username": "user1", "password": "pass1"})
+	relationSetOptions := &commands.RelationSetOptions{
+		ID:  "certificates:0",
+		App: true,
+		Data: map[string]string{
+			"username": "user1",
+			"password": "pass1",
+		},
+	}
+
+	err := command.RelationSet(relationSetOptions)
 	if err != nil {
 		t.Fatalf("RelationSet returned an error: %v", err)
 	}
@@ -193,7 +215,11 @@ func TestRelationModelGet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.RelationModelGet("certificates:0")
+	relationModelGetOptions := &commands.RelationModelGetOptions{
+		ID: "certificates:0",
+	}
+
+	result, err := command.RelationModelGet(relationModelGetOptions)
 	if err != nil {
 		t.Fatalf("RelationModelGet returned an error: %v", err)
 	}

--- a/commands/resource.go
+++ b/commands/resource.go
@@ -6,12 +6,16 @@ const (
 	resourceGetCommand = "resource-get"
 )
 
-func (command Command) ResourceGet(resourceName string) (string, error) {
-	if resourceName == "" {
+type ResourceGetOptions struct {
+	Name string
+}
+
+func (command Command) ResourceGet(opts *ResourceGetOptions) (string, error) {
+	if opts.Name == "" {
 		return "", fmt.Errorf("resource name cannot be empty")
 	}
 
-	args := []string{resourceName}
+	args := []string{opts.Name}
 
 	output, err := command.Runner.Run(resourceGetCommand, args...)
 	if err != nil {

--- a/commands/resource_test.go
+++ b/commands/resource_test.go
@@ -15,7 +15,11 @@ func TestResourceGet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.ResourceGet("software")
+	resourceGetOptions := &commands.ResourceGetOptions{
+		Name: "software",
+	}
+
+	result, err := command.ResourceGet(resourceGetOptions)
 	if err != nil {
 		t.Fatalf("ResourceGet returned an error: %v", err)
 	}

--- a/commands/secrets_test.go
+++ b/commands/secrets_test.go
@@ -57,7 +57,13 @@ func TestSecretGet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	result, err := command.SecretGet("123", "my-label", false, true)
+	secretGetOptions := &commands.SecretGetOptions{
+		ID:      "123",
+		Label:   "my-label",
+		Refresh: true,
+	}
+
+	result, err := command.SecretGet(secretGetOptions)
 	if err != nil {
 		t.Fatalf("SecretGet returned an error: %v", err)
 	}
@@ -119,7 +125,14 @@ func TestSecretAdd_Success(t *testing.T) {
 
 	expiry := time.Now().Add(24 * time.Hour)
 
-	result, err := command.SecretAdd(content, description, expiry, label, "", "")
+	secretAddOptions := &commands.SecretAddOptions{
+		Content:     content,
+		Description: description,
+		Expire:      time.Now().Add(24 * time.Hour),
+		Label:       label,
+	}
+
+	result, err := command.SecretAdd(secretAddOptions)
 	if err != nil {
 		t.Fatalf("SecretAdd returned an error: %v", err)
 	}
@@ -167,9 +180,14 @@ func TestSecretAdd_EmptyContent(t *testing.T) {
 	command := commands.Command{
 		Runner: fakeRunner,
 	}
-	expiry := time.Now().Add(24 * time.Hour)
 
-	_, err := command.SecretAdd(map[string]string{}, "desc", expiry, "my-label", "", "")
+	secretAddOptions := &commands.SecretAddOptions{
+		Description: "my secret",
+		Expire:      time.Now().Add(24 * time.Hour),
+		Label:       "my-label",
+	}
+
+	_, err := command.SecretAdd(secretAddOptions)
 	if err == nil {
 		t.Error("Expected error when content is empty, but got nil")
 	}
@@ -184,7 +202,12 @@ func TestSecretGrant_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	err := command.SecretGrant("123", "certificates:0", "")
+	secretGrantOptions := &commands.SecretGrantOptions{
+		ID:       "123",
+		Relation: "certificates:0",
+	}
+
+	err := command.SecretGrant(secretGrantOptions)
 	if err != nil {
 		t.Fatalf("SecretGrant returned an error: %v", err)
 	}
@@ -215,7 +238,11 @@ func TestSecretInfoGet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	secretInfo, err := command.SecretInfoGet("", "my-secret-label")
+	secretInfoGetOpts := &commands.SecretInfoGetOptions{
+		Label: "my-secret-label",
+	}
+
+	secretInfo, err := command.SecretInfoGet(secretInfoGetOpts)
 	if err != nil {
 		t.Fatalf("SecretInfoGet returned an error: %v", err)
 	}
@@ -274,7 +301,11 @@ func TestSecretRemove_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	err := command.SecretRemove("123")
+	secretRemoveOptions := &commands.SecretRemoveOptions{
+		ID: "123",
+	}
+
+	err := command.SecretRemove(secretRemoveOptions)
 	if err != nil {
 		t.Fatalf("SecretRemove returned an error: %v", err)
 	}
@@ -297,7 +328,11 @@ func TestSecretRevoke_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	err := command.SecretRevoke("123", "", "", "")
+	secretRevokeOpts := &commands.SecretRevokeOptions{
+		ID: "123",
+	}
+
+	err := command.SecretRevoke(secretRevokeOpts)
 	if err != nil {
 		t.Fatalf("SecretRevoke returned an error: %v", err)
 	}
@@ -325,7 +360,14 @@ func TestSecretSet_Success(t *testing.T) {
 	}
 	expiry := time.Now().Add(24 * time.Hour)
 
-	err := command.SecretSet("123", secretContent, "", expiry, "my-label", "", "")
+	secretSetOpts := &commands.SecretSetOptions{
+		ID:      "123",
+		Content: secretContent,
+		Expire:  expiry,
+		Label:   "my-label",
+	}
+
+	err := command.SecretSet(secretSetOpts)
 	if err != nil {
 		t.Fatalf("SecretSet returned an error: %v", err)
 	}

--- a/commands/state.go
+++ b/commands/state.go
@@ -11,8 +11,21 @@ const (
 	stateSetCommand    = "state-set"
 )
 
-func (command Command) StateDelete(key string) error {
-	args := []string{key}
+type StateDeleteOptions struct {
+	Key string
+}
+
+type StateGetOptions struct {
+	Key string
+}
+
+type StateSetOptions struct {
+	Key   string
+	Value string
+}
+
+func (command Command) StateDelete(opts *StateDeleteOptions) error {
+	args := []string{opts.Key}
 
 	output, err := command.Runner.Run(stateDeleteCommand, args...)
 	if err != nil {
@@ -26,12 +39,12 @@ func (command Command) StateDelete(key string) error {
 	return nil
 }
 
-func (command Command) StateGet(key string) (string, error) {
-	if key == "" {
+func (command Command) StateGet(opts *StateGetOptions) (string, error) {
+	if opts.Key == "" {
 		return "", fmt.Errorf("key cannot be empty")
 	}
 
-	args := []string{key, "--format=json"}
+	args := []string{opts.Key, "--format=json"}
 
 	output, err := command.Runner.Run(stateGetCommand, args...)
 	if err != nil {
@@ -46,22 +59,22 @@ func (command Command) StateGet(key string) (string, error) {
 	}
 
 	if len(state) == 0 {
-		return "", fmt.Errorf("no state found for key: %s", key)
+		return "", fmt.Errorf("no state found for key: %s", opts.Key)
 	}
 
 	return state, nil
 }
 
-func (command Command) StateSet(key string, value string) error {
-	if key == "" {
+func (command Command) StateSet(opts *StateSetOptions) error {
+	if opts.Key == "" {
 		return fmt.Errorf("key cannot be empty")
 	}
 
-	if value == "" {
+	if opts.Value == "" {
 		return fmt.Errorf("value cannot be empty")
 	}
 
-	args := []string{key + "=" + value}
+	args := []string{opts.Key + "=" + opts.Value}
 
 	_, err := command.Runner.Run(stateSetCommand, args...)
 	if err != nil {

--- a/commands/state.go
+++ b/commands/state.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	stateDeleteCommand = "state-delete"
+	stateGetCommand    = "state-get"
+	stateSetCommand    = "state-set"
+)
+
+func (command Command) StateDelete(key string) error {
+	args := []string{key}
+
+	output, err := command.Runner.Run(stateDeleteCommand, args...)
+	if err != nil {
+		return err
+	}
+
+	if len(output) > 0 {
+		return fmt.Errorf("unexpected output: %s", output)
+	}
+
+	return nil
+}
+
+func (command Command) StateGet(key string) (string, error) {
+	if key == "" {
+		return "", fmt.Errorf("key cannot be empty")
+	}
+
+	args := []string{key, "--format=json"}
+
+	output, err := command.Runner.Run(stateGetCommand, args...)
+	if err != nil {
+		return "", err
+	}
+
+	var state string
+
+	err = json.Unmarshal(output, &state)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse state: %w", err)
+	}
+
+	if len(state) == 0 {
+		return "", fmt.Errorf("no state found for key: %s", key)
+	}
+
+	return state, nil
+}
+
+func (command Command) StateSet(key string, value string) error {
+	if key == "" {
+		return fmt.Errorf("key cannot be empty")
+	}
+
+	if value == "" {
+		return fmt.Errorf("value cannot be empty")
+	}
+
+	args := []string{key + "=" + value}
+
+	_, err := command.Runner.Run(stateSetCommand, args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/commands/state_test.go
+++ b/commands/state_test.go
@@ -15,7 +15,11 @@ func TestStateDelete_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	err := command.StateDelete("key")
+	stateDeleteOpts := &commands.StateDeleteOptions{
+		Key: "key",
+	}
+
+	err := command.StateDelete(stateDeleteOpts)
 	if err != nil {
 		t.Fatalf("StateDelete returned an error: %v", err)
 	}
@@ -42,7 +46,11 @@ func TestStateGet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	state, err := command.StateGet("key")
+	stateGetOpts := &commands.StateGetOptions{
+		Key: "key",
+	}
+
+	state, err := command.StateGet(stateGetOpts)
 	if err != nil {
 		t.Fatalf("StateGet returned an error: %v", err)
 	}

--- a/commands/state_test.go
+++ b/commands/state_test.go
@@ -1,0 +1,69 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/gruyaume/goops/commands"
+)
+
+func TestStateDelete_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(``),
+		Err:    nil,
+	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+
+	err := command.StateDelete("key")
+	if err != nil {
+		t.Fatalf("StateDelete returned an error: %v", err)
+	}
+
+	if fakeRunner.Command != "state-delete" {
+		t.Errorf("Expected command %q, got %q", "state-delete", fakeRunner.Command)
+	}
+
+	if len(fakeRunner.Args) != 1 {
+		t.Fatalf("Expected 1 arguments, got %d", len(fakeRunner.Args))
+	}
+
+	if fakeRunner.Args[0] != "key" {
+		t.Errorf("Expected key arg %q, got %q", "key", fakeRunner.Args[0])
+	}
+}
+
+func TestStateGet_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`"value"`),
+		Err:    nil,
+	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+
+	state, err := command.StateGet("key")
+	if err != nil {
+		t.Fatalf("StateGet returned an error: %v", err)
+	}
+
+	if fakeRunner.Command != "state-get" {
+		t.Errorf("Expected command %q, got %q", "state-get", fakeRunner.Command)
+	}
+
+	if len(fakeRunner.Args) != 2 {
+		t.Fatalf("Expected 2 arguments, got %d", len(fakeRunner.Args))
+	}
+
+	if fakeRunner.Args[0] != "key" {
+		t.Errorf("Expected key arg %q, got %q", "key", fakeRunner.Args[0])
+	}
+
+	if fakeRunner.Args[1] != "--format=json" {
+		t.Errorf("Expected format arg %q, got %q", "--format=json", fakeRunner.Args[1])
+	}
+
+	if state != "value" {
+		t.Errorf("Expected state %q, got %q", "value", state)
+	}
+}

--- a/commands/status.go
+++ b/commands/status.go
@@ -1,33 +1,64 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
-type Status string
+type StatusName string
 
 const (
-	StatusActive  Status = "active"
-	StatusBlocked Status = "blocked"
-	StatusWaiting Status = "waiting"
+	StatusActive      StatusName = "active"
+	StatusBlocked     StatusName = "blocked"
+	StatusWaiting     StatusName = "waiting"
+	StatusMaintenance StatusName = "maintenance"
 )
 
 const (
-	StatusSetCommand = "status-set"
+	statusGetCommand = "status-get"
+	statusSetCommand = "status-set"
 )
 
-func (command Command) StatusSet(status Status, message string) error {
+type StatusOptions struct {
+	Name    StatusName
+	Message string
+}
+
+type Status struct {
+	Name    StatusName `json:"status"`
+	Message string     `json:"message"`
+}
+
+func (command Command) StatusSet(opts *StatusOptions) error {
 	var args []string
 
-	args = append(args, string(status))
-	if message != "" {
-		args = append(args, message)
+	args = append(args, string(opts.Name))
+	if opts.Message != "" {
+		args = append(args, opts.Message)
 	}
 
-	_, err := command.Runner.Run(StatusSetCommand, args...)
+	_, err := command.Runner.Run(statusSetCommand, args...)
 	if err != nil {
 		return fmt.Errorf("failed to set status: %w", err)
 	}
 
 	return nil
+}
+
+func (command Command) StatusGet() (*Status, error) {
+	args := []string{"--include-data", "--format=json"}
+
+	output, err := command.Runner.Run(statusGetCommand, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get status: %w", err)
+	}
+
+	var status Status
+
+	err = json.Unmarshal(output, &status)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse status: %w", err)
+	}
+
+	return &status, nil
 }

--- a/commands/status_test.go
+++ b/commands/status_test.go
@@ -15,7 +15,11 @@ func TestStatusSet_Success(t *testing.T) {
 		Runner: fakeRunner,
 	}
 
-	err := command.StatusSet(commands.StatusActive, "")
+	statusOpts := &commands.StatusOptions{
+		Name: commands.StatusActive,
+	}
+
+	err := command.StatusSet(statusOpts)
 	if err != nil {
 		t.Fatalf("StatusSet returned an error: %v", err)
 	}

--- a/commands/storage.go
+++ b/commands/storage.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	storageAddCommand  = "storage-add"
+	storageGetCommand  = "storage-get"
+	storageListCommand = "storage-list"
+)
+
+type StorageAddOptions struct {
+	Name  string
+	Count int
+}
+
+type StorageGetOptions struct {
+	ID   string
+	Name string
+}
+
+type StorageListOptions struct {
+	Name string
+}
+
+func (command Command) StorageAdd(opts *StorageAddOptions) error {
+	if opts.Name == "" {
+		return fmt.Errorf("storage name cannot be empty")
+	}
+
+	args := []string{}
+
+	if opts.Count > 0 {
+		args = append(args, opts.Name+"="+fmt.Sprintf("%d", opts.Count))
+	} else {
+		args = append(args, opts.Name)
+	}
+
+	_, err := command.Runner.Run(storageAddCommand, args...)
+	if err != nil {
+		return fmt.Errorf("failed to add storage: %w", err)
+	}
+
+	return nil
+}
+
+func (command Command) StorageGet(opts *StorageGetOptions) (string, error) {
+	if opts.ID == "" && opts.Name == "" {
+		return "", fmt.Errorf("either ID or Name must be provided")
+	}
+
+	args := []string{}
+
+	if opts.ID != "" {
+		args = append(args, opts.ID)
+	}
+
+	if opts.Name != "" {
+		args = append(args, "-s", opts.Name)
+	}
+
+	args = append(args, "--format=json")
+
+	output, err := command.Runner.Run(storageGetCommand, args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to get storage: %w", err)
+	}
+
+	var storage string
+
+	err = json.Unmarshal(output, &storage)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse storage: %w", err)
+	}
+
+	return storage, nil
+}
+
+func (command Command) StorageList(opts *StorageListOptions) ([]string, error) {
+	if opts.Name == "" {
+		return nil, fmt.Errorf("storage name cannot be empty")
+	}
+
+	args := []string{opts.Name, "--format=json"}
+
+	output, err := command.Runner.Run(storageListCommand, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list storage: %w", err)
+	}
+
+	var storageNames []string
+
+	err = json.Unmarshal(output, &storageNames)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse storages: %w", err)
+	}
+
+	return storageNames, nil
+}

--- a/commands/storage_test.go
+++ b/commands/storage_test.go
@@ -1,0 +1,199 @@
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/gruyaume/goops/commands"
+)
+
+func TestStorageAdd_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(``),
+		Err:    nil,
+	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+
+	storageAddOpts := &commands.StorageAddOptions{
+		Name: "database-storage",
+	}
+
+	err := command.StorageAdd(storageAddOpts)
+	if err != nil {
+		t.Fatalf("StorageAdd returned an error: %v", err)
+	}
+
+	if fakeRunner.Command != "storage-add" {
+		t.Errorf("Expected command %q, got %q", "storage-add", fakeRunner.Command)
+	}
+
+	if len(fakeRunner.Args) != 1 {
+		t.Fatalf("Expected 1 argument, got %d", len(fakeRunner.Args))
+	}
+
+	if fakeRunner.Args[0] != "database-storage" {
+		t.Errorf("Expected argument %q, got %q", "database-storage", fakeRunner.Args[0])
+	}
+}
+
+func TestStorageAddWithCount_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(``),
+		Err:    nil,
+	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+
+	storageAddOpts := &commands.StorageAddOptions{
+		Name:  "database-storage",
+		Count: 2,
+	}
+
+	err := command.StorageAdd(storageAddOpts)
+	if err != nil {
+		t.Fatalf("StorageAdd returned an error: %v", err)
+	}
+
+	if fakeRunner.Command != "storage-add" {
+		t.Errorf("Expected command %q, got %q", "storage-add", fakeRunner.Command)
+	}
+
+	if len(fakeRunner.Args) != 1 {
+		t.Fatalf("Expected 1 argument, got %d", len(fakeRunner.Args))
+	}
+
+	if fakeRunner.Args[0] != "database-storage=2" {
+		t.Errorf("Expected argument %q, got %q", "database-storage=2", fakeRunner.Args[0])
+	}
+}
+
+func TestStorageGetByName_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`"database-storage"`),
+		Err:    nil,
+	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+
+	storageGetOpts := &commands.StorageGetOptions{
+		Name: "database-storage",
+	}
+
+	storage, err := command.StorageGet(storageGetOpts)
+	if err != nil {
+		t.Fatalf("StorageGet returned an error: %v", err)
+	}
+
+	if fakeRunner.Command != "storage-get" {
+		t.Errorf("Expected command %q, got %q", "storage-get", fakeRunner.Command)
+	}
+
+	if len(fakeRunner.Args) != 3 {
+		t.Fatalf("Expected 3 argument, got %d", len(fakeRunner.Args))
+	}
+
+	if fakeRunner.Args[0] != "-s" {
+		t.Errorf("Expected argument %q, got %q", "-s", fakeRunner.Args[0])
+	}
+
+	if fakeRunner.Args[1] != "database-storage" {
+		t.Errorf("Expected argument %q, got %q", "database-storage", fakeRunner.Args[1])
+	}
+
+	if fakeRunner.Args[2] != "--format=json" {
+		t.Errorf("Expected argument %q, got %q", "--format=json", fakeRunner.Args[2])
+	}
+
+	if storage != "database-storage" {
+		t.Errorf("Expected storage %q, got %q", "database-storage", storage)
+	}
+}
+
+func TestStorageGetByID_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`"database-storage"`),
+		Err:    nil,
+	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+
+	storageGetOpts := &commands.StorageGetOptions{
+		ID: "21127934-8986-11e5-af63-feff819cdc9f",
+	}
+
+	storage, err := command.StorageGet(storageGetOpts)
+	if err != nil {
+		t.Fatalf("StorageGet returned an error: %v", err)
+	}
+
+	if fakeRunner.Command != "storage-get" {
+		t.Errorf("Expected command %q, got %q", "storage-get", fakeRunner.Command)
+	}
+
+	if len(fakeRunner.Args) != 2 {
+		t.Fatalf("Expected 3 argument, got %d", len(fakeRunner.Args))
+	}
+
+	if fakeRunner.Args[0] != "21127934-8986-11e5-af63-feff819cdc9f" {
+		t.Errorf("Expected argument %q, got %q", "21127934-8986-11e5-af63-feff819cdc9f", fakeRunner.Args[0])
+	}
+
+	if fakeRunner.Args[1] != "--format=json" {
+		t.Errorf("Expected argument %q, got %q", "--format=json", fakeRunner.Args[1])
+	}
+
+	if storage != "database-storage" {
+		t.Errorf("Expected storage %q, got %q", "database-storage", storage)
+	}
+}
+
+func TestStorageList_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`["database-storage/0","database-storage/1"]`),
+		Err:    nil,
+	}
+	command := commands.Command{
+		Runner: fakeRunner,
+	}
+
+	storageListOpts := &commands.StorageListOptions{
+		Name: "database-storage",
+	}
+
+	storage, err := command.StorageList(storageListOpts)
+	if err != nil {
+		t.Fatalf("StorageList returned an error: %v", err)
+	}
+
+	if fakeRunner.Command != "storage-list" {
+		t.Errorf("Expected command %q, got %q", "storage-list", fakeRunner.Command)
+	}
+
+	if len(fakeRunner.Args) != 2 {
+		t.Fatalf("Expected 2 argument, got %d", len(fakeRunner.Args))
+	}
+
+	if fakeRunner.Args[0] != "database-storage" {
+		t.Errorf("Expected argument %q, got %q", "database-storage", fakeRunner.Args[0])
+	}
+
+	if fakeRunner.Args[1] != "--format=json" {
+		t.Errorf("Expected argument %q, got %q", "--format=json", fakeRunner.Args[1])
+	}
+
+	if len(storage) != 2 {
+		t.Errorf("Expected 2 storage items, got %d", len(storage))
+	}
+
+	if storage[0] != "database-storage/0" {
+		t.Errorf("Expected storage item %q, got %q", "database-storage/0", storage[0])
+	}
+
+	if storage[1] != "database-storage/1" {
+		t.Errorf("Expected storage item %q, got %q", "database-storage/1", storage[1])
+	}
+}

--- a/commands/unit.go
+++ b/commands/unit.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	unitGetCommand = "unit-get"
+)
+
+type UnitGetOptions struct {
+	PrivateAddress bool
+	PublicAddress  bool
+}
+
+func (command Command) UnitGet(opts *UnitGetOptions) (string, error) {
+	if !opts.PrivateAddress && !opts.PublicAddress {
+		return "", fmt.Errorf("must specify either private or public address")
+	}
+
+	if opts.PrivateAddress && opts.PublicAddress {
+		return "", fmt.Errorf("cannot specify both private and public address")
+	}
+
+	args := []string{}
+
+	if opts.PrivateAddress {
+		args = append(args, "private-address")
+	}
+
+	if opts.PublicAddress {
+		args = append(args, "public-address")
+	}
+
+	args = append(args, "--format=json")
+
+	output, err := command.Runner.Run(unitGetCommand, args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to get unit: %w", err)
+	}
+
+	var result string
+	if err := json.Unmarshal(output, &result); err != nil {
+		return "", fmt.Errorf("failed to parse unit get output: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/charm/actions.go
+++ b/internal/charm/actions.go
@@ -4,12 +4,22 @@ import (
 	"fmt"
 
 	"github.com/gruyaume/goops"
+	"github.com/gruyaume/goops/commands"
 )
 
 func HandleGetCACertificateAction(hookContext *goops.HookContext) error {
-	caCertificateSecret, err := hookContext.Commands.SecretGet("", CaCertificateSecretLabel, false, true)
+	secretGetOptions := &commands.SecretGetOptions{
+		Label:   CaCertificateSecretLabel,
+		Refresh: true,
+	}
+
+	caCertificateSecret, err := hookContext.Commands.SecretGet(secretGetOptions)
 	if err != nil {
-		err := hookContext.Commands.ActionFail("could not get CA certificate secret")
+		actionFailOptions := &commands.ActionFailOptions{
+			Message: "could not get CA certificate secret",
+		}
+
+		err := hookContext.Commands.ActionFail(actionFailOptions)
 		if err != nil {
 			return fmt.Errorf("could not fail action: %w and could not get CA certificate secret: %w", err, err)
 		}
@@ -19,7 +29,11 @@ func HandleGetCACertificateAction(hookContext *goops.HookContext) error {
 
 	caCertPEM, ok := caCertificateSecret["ca-certificate"]
 	if !ok {
-		err := hookContext.Commands.ActionFail("could not find CA certificate in secret")
+		actionFailOptions := &commands.ActionFailOptions{
+			Message: "could not find CA certificate in secret",
+		}
+
+		err := hookContext.Commands.ActionFail(actionFailOptions)
 		if err != nil {
 			return fmt.Errorf("could not fail action: %w and could not find CA certificate in secret: %w", err, err)
 		}
@@ -27,9 +41,19 @@ func HandleGetCACertificateAction(hookContext *goops.HookContext) error {
 		return fmt.Errorf("could not find CA certificate in secret")
 	}
 
-	err = hookContext.Commands.ActionSet(map[string]string{"ca-certificate": caCertPEM})
+	actionSetOptions := &commands.ActionSetOptions{
+		Content: map[string]string{
+			"ca-certificate": caCertPEM,
+		},
+	}
+
+	err = hookContext.Commands.ActionSet(actionSetOptions)
 	if err != nil {
-		err := hookContext.Commands.ActionFail("could not set action result")
+		actionFailOptions := &commands.ActionFailOptions{
+			Message: "could not set action result",
+		}
+
+		err := hookContext.Commands.ActionFail(actionFailOptions)
 		if err != nil {
 			return fmt.Errorf("could not fail action: %w and could not set action result: %w", err, err)
 		}

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -276,6 +276,21 @@ func HandleDefaultHook(hookContext *goops.HookContext) error {
 		return fmt.Errorf("could not set ports: %w", err)
 	}
 
+	unitGetOpts := &commands.UnitGetOptions{
+		PrivateAddress: true,
+	}
+
+	privateAddress, err := hookContext.Commands.UnitGet(unitGetOpts)
+	if err != nil {
+		return fmt.Errorf("could not get unit private address: %w", err)
+	}
+
+	if privateAddress == "" {
+		return fmt.Errorf("unit private address is empty")
+	}
+
+	hookContext.Commands.JujuLog(commands.Info, "Unit private address:", privateAddress)
+
 	hookContext.Commands.JujuLog(commands.Info, "Set unit ports")
 
 	valid, err := isConfigValid(hookContext)

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -311,7 +311,19 @@ func HandleDefaultHook(hookContext *goops.HookContext) error {
 		return fmt.Errorf("could not set application version: %w", err)
 	}
 
-	err = hookContext.Commands.StatusSet(commands.StatusActive, "")
+	existingStatus, err := hookContext.Commands.StatusGet()
+	if err != nil {
+		return fmt.Errorf("could not get status: %w", err)
+	}
+
+	hookContext.Commands.JujuLog(commands.Info, "Current status:", string(existingStatus.Name), existingStatus.Message)
+
+	statusOpts := &commands.StatusOptions{
+		Name:    commands.StatusActive,
+		Message: "A happy charm",
+	}
+
+	err = hookContext.Commands.StatusSet(statusOpts)
 	if err != nil {
 		return fmt.Errorf("could not set status: %w", err)
 	}

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -2,6 +2,7 @@ package charm
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/gruyaume/goops"
 	"github.com/gruyaume/goops/commands"
@@ -48,7 +49,14 @@ func generateAndStoreRootCertificate(hookContext *goops.HookContext) error {
 			"ca-certificate": caCertPEM,
 		}
 
-		output, err := hookContext.Commands.SecretAdd(secretContent, "", CaCertificateSecretLabel)
+		expiry := time.Now().AddDate(1, 0, 0)
+
+		output, err := hookContext.Commands.SecretAdd(
+			secretContent,
+			"ca certificate and private key for the certificates charm",
+			expiry,
+			CaCertificateSecretLabel,
+			"", "")
 		if err != nil {
 			return fmt.Errorf("could not add secret: %w", err)
 		}

--- a/internal/integrations/tls_certificates/tls_certificates_integration.go
+++ b/internal/integrations/tls_certificates/tls_certificates_integration.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/gruyaume/goops"
+	"github.com/gruyaume/goops/commands"
 )
 
 type CertificateSigningRequestRequirerRelationData struct {
@@ -76,7 +77,11 @@ func GetOutstandingCertificateRequests(hookContext *goops.HookContext, relationN
 		return nil, fmt.Errorf("relation name is empty")
 	}
 
-	relationIDs, err := hookContext.Commands.RelationIDs(relationName)
+	relationIDsOptions := &commands.RelationIDsOptions{
+		Name: relationName,
+	}
+
+	relationIDs, err := hookContext.Commands.RelationIDs(relationIDsOptions)
 	if err != nil {
 		return nil, fmt.Errorf("could not get relation IDs: %w", err)
 	}
@@ -84,13 +89,22 @@ func GetOutstandingCertificateRequests(hookContext *goops.HookContext, relationN
 	requirerCertificateRequests := make([]RequirerCertificateRequest, 0)
 
 	for _, relationID := range relationIDs {
-		relationUnits, err := hookContext.Commands.RelationList(relationID)
+		relationListOptions := &commands.RelationListOptions{
+			ID: relationID,
+		}
+
+		relationUnits, err := hookContext.Commands.RelationList(relationListOptions)
 		if err != nil {
 			return nil, fmt.Errorf("could not list relation data: %w", err)
 		}
 
 		for _, unitID := range relationUnits {
-			relationData, err := hookContext.Commands.RelationGet(relationID, unitID, false)
+			relationGetOptions := &commands.RelationGetOptions{
+				ID:     relationID,
+				UnitID: unitID,
+			}
+
+			relationData, err := hookContext.Commands.RelationGet(relationGetOptions)
 			if err != nil {
 				return nil, fmt.Errorf("could not get relation data: %w", err)
 			}
@@ -150,7 +164,13 @@ func SetRelationCertificate(hookContext *goops.HookContext, relationID string, p
 		"certificates": string(appDataJSON),
 	}
 
-	err = hookContext.Commands.RelationSet(relationID, true, relationData)
+	relationSetOptions := &commands.RelationSetOptions{
+		ID:   relationID,
+		App:  true,
+		Data: relationData,
+	}
+
+	err = hookContext.Commands.RelationSet(relationSetOptions)
 	if err != nil {
 		return fmt.Errorf("could not set relation data: %w", err)
 	}


### PR DESCRIPTION
# Description

Add the following commands:

Secret
- secret-remove
- secret-revoke
- secret-set

State
- state-delete
- state-get
- state-set

Status
- status-get
- status set

Storage
- storage-add
- storage-get
- storage-list

Unit
- unit-get

Also use struct parameters instead of explicitly listing them to reduce risk related to breaking changes.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
