### PR TITLE
feat: simplify retrieving charm metadata

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,16 +3,24 @@ package goops
 import (
 	"github.com/gruyaume/goops/commands"
 	"github.com/gruyaume/goops/environment"
+	"github.com/gruyaume/goops/metadata"
 )
 
 type HookContext struct {
 	Commands    *commands.Command
 	Environment *environment.Environment
+	Metadata    *metadata.Metadata
 }
 
 func NewHookContext() *HookContext {
+	env := environment.NewEnvironment()
+
+	charmDir := env.JujuCharmDir()
+	metadataPath := charmDir + "/metadata.yaml"
+
 	return &HookContext{
 		Commands:    commands.NewCommand(),
-		Environment: environment.NewEnvironment(),
+		Environment: env,
+		Metadata:    metadata.GetCharmMetadata(metadataPath),
 	}
 }

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gruyaume/goops"
 	"github.com/gruyaume/goops/commands"
 	"github.com/gruyaume/goops/internal/integrations/tls_certificates"
-	"github.com/gruyaume/goops/metadata"
 )
 
 const (
@@ -272,12 +271,7 @@ func HandleDefaultHook(hookContext *goops.HookContext) error {
 		return fmt.Errorf("unit is not leader")
 	}
 
-	meta, err := metadata.GetCharmMetadata(hookContext.Environment)
-	if err != nil {
-		return fmt.Errorf("could not get charm metadata: %w", err)
-	}
-
-	hookContext.Commands.JujuLog(commands.Info, "Charm Name:", meta.Name)
+	hookContext.Commands.JujuLog(commands.Info, "Charm Name:", hookContext.Metadata.Name)
 
 	err = setPorts(hookContext)
 	if err != nil {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,10 +1,8 @@
 package metadata
 
 import (
-	"fmt"
 	"os"
 
-	"github.com/gruyaume/goops/environment"
 	"gopkg.in/yaml.v3"
 )
 
@@ -43,21 +41,18 @@ type Metadata struct {
 	Summary     string                 `yaml:"summary"`
 }
 
-func GetCharmMetadata(env *environment.Environment) (Metadata, error) {
-	charmDir := env.JujuCharmDir()
-	metadataPath := charmDir + "/metadata.yaml"
-
-	yamlFile, err := os.ReadFile(metadataPath) // #nosec G304
+func GetCharmMetadata(path string) *Metadata {
+	yamlFile, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
-		return Metadata{}, fmt.Errorf("error reading metadata.yaml: %w", err)
+		return nil
 	}
 
 	var c Metadata
 
 	err = yaml.Unmarshal(yamlFile, &c)
 	if err != nil {
-		return Metadata{}, fmt.Errorf("error unmarshalling metadata.yaml: %w", err)
+		return nil
 	}
 
-	return c, nil
+	return &c
 }

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gruyaume/goops/environment"
 	"github.com/gruyaume/goops/metadata"
 )
 
@@ -61,15 +60,9 @@ func TestGetCharmMetadata_Success(t *testing.T) {
 		t.Fatalf("failed to write metadata.yaml: %v", err)
 	}
 
-	env := &environment.Environment{
-		Getter: &TestExecutionEnvironment{
-			CharmDir: tmpDir,
-		},
-	}
-
-	meta, err := metadata.GetCharmMetadata(env)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	meta := metadata.GetCharmMetadata(metadataPath)
+	if meta == nil {
+		t.Fatalf("GetCharmMetadata returned nil")
 	}
 
 	if meta.Name != "notary-k8s" {


### PR DESCRIPTION
# Description

Provide charm metadata through the same hook context as environment and commands. We fetch the metadata for users, so that they can access content directly at any point without having to load the file unnecessarily.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
