### PR TITLE
fix[goopstest]: output an empty string when no relation-ids

### DIFF
--- a/goopstest/goopstest.go
+++ b/goopstest/goopstest.go
@@ -195,6 +195,11 @@ func (f *fakeRunner) handleConfigGet(args []string) {
 }
 
 func (f *fakeRunner) handleRelationIDs(args []string) {
+	if len(f.Relations) == 0 {
+		f.Output = []byte(`[]`)
+		return
+	}
+
 	for _, relation := range f.Relations {
 		if len(args) > 0 && args[0] == relation.Endpoint {
 			if relation.ID != "" {

--- a/goopstest/relation_test.go
+++ b/goopstest/relation_test.go
@@ -46,6 +46,36 @@ func TestCharmGetRelationIDs(t *testing.T) {
 	}
 }
 
+func GetRelationIDsNoRelation() error {
+	relationIDs, err := goops.GetRelationIDs("certificates")
+	if err != nil {
+		return err
+	}
+
+	if len(relationIDs) != 0 {
+		return fmt.Errorf("expected no relation IDs, got %d", len(relationIDs))
+	}
+
+	return nil
+}
+
+func TestCharmGetRelationIDsNoRelation(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: GetRelationIDsNoRelation,
+	}
+
+	stateIn := &goopstest.State{}
+
+	stateOut, err := ctx.Run("start", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if len(stateOut.Relations) != 0 {
+		t.Fatalf("expected no relations, got %d", len(stateOut.Relations))
+	}
+}
+
 func ListRelationUnits1Result() error {
 	relationUnits, err := goops.ListRelationUnits("certificates:0")
 	if err != nil {


### PR DESCRIPTION
# Description

fix[goopstest]: output an empty string when no relation-ids

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
