### PR TITLE
feat: add SecretRotate type

### DIFF
--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -55,6 +55,7 @@ func generateAndStoreRootCertificate() error {
 			Description: "ca certificate and private key for the certificates charm",
 			Expire:      expiry,
 			Label:       CaCertificateSecretLabel,
+			Rotate:      goops.RotateNever,
 		})
 		if err != nil {
 			return fmt.Errorf("could not add secret: %w", err)

--- a/secrets.go
+++ b/secrets.go
@@ -24,6 +24,15 @@ type SecretInfo struct {
 	Rotation string `json:"rotation"`
 }
 
+type SecretRotate string
+
+const (
+	RotateHourly  SecretRotate = "hourly"
+	RotateDaily   SecretRotate = "daily"
+	RotateMonthly SecretRotate = "monthly"
+	RotateNever   SecretRotate = "never"
+)
+
 type SetSecretOptions struct {
 	ID          string
 	Content     map[string]string
@@ -31,7 +40,7 @@ type SetSecretOptions struct {
 	Expire      time.Time
 	Label       string
 	Owner       string
-	Rotate      string // allowed values: hourly, daily, monthly, never
+	Rotate      SecretRotate
 }
 
 type AddSecretOptions struct {
@@ -40,7 +49,7 @@ type AddSecretOptions struct {
 	Expire      time.Time
 	Label       string
 	Owner       string
-	Rotate      string // allowed values: hourly, daily, monthly, never
+	Rotate      SecretRotate
 }
 
 func AddSecret(opts *AddSecretOptions) (string, error) {
@@ -68,7 +77,7 @@ func AddSecret(opts *AddSecretOptions) (string, error) {
 	}
 
 	if opts.Rotate != "" {
-		args = append(args, "--rotate="+opts.Rotate)
+		args = append(args, "--rotate="+string(opts.Rotate))
 	}
 
 	if !opts.Expire.IsZero() {
@@ -324,7 +333,7 @@ func RevokeSecretFromUnit(id string, unit string) error {
 	return nil
 }
 
-func SecretSet(opts *SetSecretOptions) error {
+func SetSecret(opts *SetSecretOptions) error {
 	commandRunner := GetRunner()
 
 	if opts.ID == "" {
@@ -353,7 +362,7 @@ func SecretSet(opts *SetSecretOptions) error {
 	}
 
 	if opts.Rotate != "" {
-		args = append(args, "--rotate="+opts.Rotate)
+		args = append(args, "--rotate="+string(opts.Rotate))
 	}
 
 	if !opts.Expire.IsZero() {

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -117,6 +117,7 @@ func TestSecretAdd_Success(t *testing.T) {
 		Description: description,
 		Expire:      time.Now().Add(24 * time.Hour),
 		Label:       label,
+		Rotate:      goops.RotateNever,
 	}
 
 	result, err := goops.AddSecret(secretAddOptions)
@@ -133,8 +134,8 @@ func TestSecretAdd_Success(t *testing.T) {
 		t.Errorf("Expected command %q, got %q", "secret-add", fakeRunner.Command)
 	}
 
-	if len(fakeRunner.Args) != 5 {
-		t.Fatalf("Expected 5 arguments, got %d", len(fakeRunner.Args))
+	if len(fakeRunner.Args) != 6 {
+		t.Fatalf("Expected 6 arguments, got %d", len(fakeRunner.Args))
 	}
 
 	contentArg := fakeRunner.Args[0]
@@ -154,8 +155,12 @@ func TestSecretAdd_Success(t *testing.T) {
 		t.Errorf("Expected label arg %q, got %q", "--label=my-label", fakeRunner.Args[3])
 	}
 
-	if fakeRunner.Args[4] != "--expire="+expiry.Format(time.RFC3339) {
-		t.Errorf("Expected expire arg %q, got %q", "--expire="+expiry.Format(time.RFC3339), fakeRunner.Args[4])
+	if fakeRunner.Args[4] != "--rotate=never" {
+		t.Errorf("Expected rotate arg %q, got %q", "--rotate=never", fakeRunner.Args[4])
+	}
+
+	if fakeRunner.Args[5] != "--expire="+expiry.Format(time.RFC3339) {
+		t.Errorf("Expected expire arg %q, got %q", "--expire="+expiry.Format(time.RFC3339), fakeRunner.Args[5])
 	}
 }
 
@@ -171,6 +176,7 @@ func TestSecretAdd_EmptyContent(t *testing.T) {
 		Description: "my secret",
 		Expire:      time.Now().Add(24 * time.Hour),
 		Label:       "my-label",
+		Rotate:      goops.RotateNever,
 	}
 
 	_, err := goops.AddSecret(secretAddOptions)
@@ -325,20 +331,21 @@ func TestSecretSet_Success(t *testing.T) {
 	}
 	expiry := time.Now().Add(24 * time.Hour)
 
-	secretSetOpts := &goops.SetSecretOptions{
+	setSecretOpts := &goops.SetSecretOptions{
 		ID:      "123",
 		Content: secretContent,
 		Expire:  expiry,
 		Label:   "my-label",
+		Rotate:  goops.RotateNever,
 	}
 
-	err := goops.SecretSet(secretSetOpts)
+	err := goops.SetSecret(setSecretOpts)
 	if err != nil {
-		t.Fatalf("SecretSet returned an error: %v", err)
+		t.Fatalf("couldn't set secret: %v", err)
 	}
 
-	if len(fakeRunner.Args) != 4 {
-		t.Fatalf("Expected 4 arguments, got %d", len(fakeRunner.Args))
+	if len(fakeRunner.Args) != 5 {
+		t.Fatalf("Expected 5 arguments, got %d", len(fakeRunner.Args))
 	}
 
 	if fakeRunner.Args[0] != "username=user1" && fakeRunner.Args[1] != "username=user1" {
@@ -351,5 +358,13 @@ func TestSecretSet_Success(t *testing.T) {
 
 	if fakeRunner.Args[2] != "--label=my-label" {
 		t.Errorf("Expected ID arg %q, got %q", "--label=my-label", fakeRunner.Args[2])
+	}
+
+	if fakeRunner.Args[3] != "--rotate=never" {
+		t.Errorf("Expected ID arg %q, got %q", "--rotate=never", fakeRunner.Args[3])
+	}
+
+	if fakeRunner.Args[4] != "--expire="+expiry.Format(time.RFC3339) {
+		t.Errorf("Expected ID arg %q, got %q", "--expire="+expiry.Format(time.RFC3339), fakeRunner.Args[4])
 	}
 }


### PR DESCRIPTION
# Description

As requested in #34 , we replace the use of bare strings for specifying secret rotation time with a  `type SecretRotate string`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
