### PR TITLE
feat: rename GetStatus to GetUnitStatus and add GetAppStatus

### DIFF
--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -328,12 +328,12 @@ func Configure() error {
 		return fmt.Errorf("could not set application version using goops: %w", err)
 	}
 
-	existingStatus, err := goops.GetStatus()
+	existingStatus, err := goops.GetUnitStatus()
 	if err != nil {
-		return fmt.Errorf("could not get status: %w", err)
+		return fmt.Errorf("could not get unit status: %w", err)
 	}
 
-	goops.LogInfof("Current status: %s %s", existingStatus.Code, existingStatus.Message)
+	goops.LogInfof("Current unit status: %s %s", existingStatus.Code, existingStatus.Message)
 
 	err = goops.SetUnitStatus(goops.StatusActive, "A happy charm")
 	if err != nil {

--- a/status.go
+++ b/status.go
@@ -62,7 +62,7 @@ func SetAppStatus(status StatusCode, message ...string) error {
 	return nil
 }
 
-func GetStatus() (*Status, error) {
+func GetUnitStatus() (*Status, error) {
 	commandRunner := GetRunner()
 
 	args := []string{"--include-data", "--format=json"}
@@ -77,6 +77,26 @@ func GetStatus() (*Status, error) {
 	err = json.Unmarshal(output, &status)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse status: %w", err)
+	}
+
+	return &status, nil
+}
+
+func GetAppStatus() (*Status, error) {
+	commandRunner := GetRunner()
+
+	args := []string{"--application", "--include-data", "--format=json"}
+
+	output, err := commandRunner.Run(statusGetCommand, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get application status: %w", err)
+	}
+
+	var status Status
+
+	err = json.Unmarshal(output, &status)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse application status: %w", err)
 	}
 
 	return &status, nil

--- a/status_test.go
+++ b/status_test.go
@@ -69,3 +69,83 @@ func TestSetAppStatus_Success(t *testing.T) {
 		t.Errorf("Expected no output, got %q", string(fakeRunner.Output))
 	}
 }
+
+func TestGetUnitStatus_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`{"status": "active", "message": "Unit is active"}`),
+		Err:    nil,
+	}
+
+	goops.SetRunner(fakeRunner)
+
+	status, err := goops.GetUnitStatus()
+	if err != nil {
+		t.Fatalf("GetUnitStatus returned an error: %v", err)
+	}
+
+	if status.Code != goops.StatusActive {
+		t.Errorf("Expected status %q, got %q", goops.StatusActive, status.Code)
+	}
+
+	if status.Message != "Unit is active" {
+		t.Errorf("Expected message %q, got %q", "Unit is active", status.Message)
+	}
+
+	if fakeRunner.Command != "status-get" {
+		t.Errorf("Expected command %q, got %q", "status-get", fakeRunner.Command)
+	}
+
+	if len(fakeRunner.Args) != 2 {
+		t.Fatalf("Expected 2 argument, got %d", len(fakeRunner.Args))
+	}
+
+	if fakeRunner.Args[0] != "--include-data" {
+		t.Errorf("Expected argument %q, got %q", "--include-data", fakeRunner.Args[0])
+	}
+
+	if fakeRunner.Args[1] != "--format=json" {
+		t.Errorf("Expected argument %q, got %q", "--format=json", fakeRunner.Args[1])
+	}
+}
+
+func TestGetAppStatus_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(`{"status": "active", "message": "Application is active"}`),
+		Err:    nil,
+	}
+
+	goops.SetRunner(fakeRunner)
+
+	status, err := goops.GetAppStatus()
+	if err != nil {
+		t.Fatalf("GetAppStatus returned an error: %v", err)
+	}
+
+	if status.Code != goops.StatusActive {
+		t.Errorf("Expected status %q, got %q", goops.StatusActive, status.Code)
+	}
+
+	if status.Message != "Application is active" {
+		t.Errorf("Expected message %q, got %q", "Application is active", status.Message)
+	}
+
+	if fakeRunner.Command != "status-get" {
+		t.Errorf("Expected command %q, got %q", "status-get", fakeRunner.Command)
+	}
+
+	if len(fakeRunner.Args) != 3 {
+		t.Fatalf("Expected 3 argument, got %d", len(fakeRunner.Args))
+	}
+
+	if fakeRunner.Args[0] != "--application" {
+		t.Errorf("Expected argument %q, got %q", "--application", fakeRunner.Args[0])
+	}
+
+	if fakeRunner.Args[1] != "--include-data" {
+		t.Errorf("Expected argument %q, got %q", "--include-data", fakeRunner.Args[1])
+	}
+
+	if fakeRunner.Args[2] != "--format=json" {
+		t.Errorf("Expected argument %q, got %q", "--format=json", fakeRunner.Args[2])
+	}
+}


### PR DESCRIPTION
# Description

In the context of addressing review comments from #34, here we add `GetUnitStatus` and `GetAppStatus` to match with `SetUnitStatus` and `SetAppStatus`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
