### PR TITLE
feat: simplify function names and network operations

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -13,7 +13,7 @@ const (
 )
 
 func FailActionf(format string, args ...any) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	message := fmt.Sprintf(format, args...)
 
@@ -26,7 +26,7 @@ func FailActionf(format string, args ...any) error {
 }
 
 func GetActionParameter(key string) (string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{key, "--format=json"}
 
@@ -45,8 +45,9 @@ func GetActionParameter(key string) (string, error) {
 	return actionParameter, nil
 }
 
-func LogActionf(format string, args ...any) error {
-	commandRunner := GetRunner()
+// ActionLogf records a progress message for the current action.
+func ActionLogf(format string, args ...any) error {
+	commandRunner := GetCommandRunner()
 
 	message := fmt.Sprintf(format, args...)
 
@@ -59,7 +60,7 @@ func LogActionf(format string, args ...any) error {
 }
 
 func SetActionResults(results map[string]string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	var args []string
 

--- a/actions.go
+++ b/actions.go
@@ -25,24 +25,22 @@ func FailActionf(format string, args ...any) error {
 	return nil
 }
 
-func GetActionParameter(key string) (string, error) {
+func GetActionParams(params any) error {
 	commandRunner := GetCommandRunner()
 
-	args := []string{key, "--format=json"}
+	args := []string{"--format=json"}
 
 	output, err := commandRunner.Run(actionGetCommand, args...)
 	if err != nil {
-		return "", fmt.Errorf("failed to get action parameter: %w", err)
+		return fmt.Errorf("failed to get action parameter: %w", err)
 	}
 
-	var actionParameter string
-
-	err = json.Unmarshal(output, &actionParameter)
+	err = json.Unmarshal(output, params)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse action parameter: %w", err)
+		return fmt.Errorf("failed to parse action parameter: %w", err)
 	}
 
-	return actionParameter, nil
+	return nil
 }
 
 // ActionLogf records a progress message for the current action.

--- a/actions_test.go
+++ b/actions_test.go
@@ -12,7 +12,7 @@ func TestActionFail_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.FailActionf("my failure message")
 	if err != nil {
@@ -38,7 +38,7 @@ func TestActionGet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	result, err := goops.GetActionParameter("fruit")
 	if err != nil {
@@ -72,9 +72,9 @@ func TestActionLog_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
-	err := goops.LogActionf("my log message")
+	err := goops.ActionLogf("my log message")
 	if err != nil {
 		t.Fatalf("ActionLog returned an error: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestActionSet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	actionSetValues := map[string]string{
 		"fruit": "banana",

--- a/actions_test.go
+++ b/actions_test.go
@@ -32,37 +32,44 @@ func TestActionFail_Success(t *testing.T) {
 	}
 }
 
+type MyActionParams struct {
+	Fruit string `json:"fruit"`
+	Color string `json:"color"`
+}
+
 func TestActionGet_Success(t *testing.T) {
 	fakeRunner := &FakeRunner{
-		Output: []byte(`"banana"`),
+		Output: []byte(`{"fruit": "banana"}`),
 		Err:    nil,
 	}
 
 	goops.SetCommandRunner(fakeRunner)
 
-	result, err := goops.GetActionParameter("fruit")
+	actionParams := MyActionParams{}
+
+	err := goops.GetActionParams(&actionParams)
 	if err != nil {
 		t.Fatalf("ActionGet returned an error: %v", err)
 	}
 
-	if result != "banana" {
-		t.Fatalf("Expected %q, got %q", "banana", result)
+	if actionParams.Fruit != "banana" {
+		t.Fatalf("Expected %q, got %q", "banana", actionParams.Fruit)
+	}
+
+	if actionParams.Color != "" {
+		t.Fatalf("Expected color to be empty, got %q", actionParams.Color)
 	}
 
 	if fakeRunner.Command != "action-get" {
 		t.Errorf("Expected command %q, got %q", "action-get", fakeRunner.Command)
 	}
 
-	if len(fakeRunner.Args) != 2 {
-		t.Fatalf("Expected 2 arguments, got %d", len(fakeRunner.Args))
+	if len(fakeRunner.Args) != 1 {
+		t.Fatalf("Expected 1 argument, got %d", len(fakeRunner.Args))
 	}
 
-	if fakeRunner.Args[0] != "fruit" {
-		t.Errorf("Expected argument %q, got %q", "fruit", fakeRunner.Args[0])
-	}
-
-	if fakeRunner.Args[1] != "--format=json" {
-		t.Errorf("Expected argument %q, got %q", "--format=json", fakeRunner.Args[1])
+	if fakeRunner.Args[0] != "--format=json" {
+		t.Errorf("Expected argument %q, got %q", "--format=json", fakeRunner.Args[0])
 	}
 }
 

--- a/application_version.go
+++ b/application_version.go
@@ -6,8 +6,8 @@ const (
 	applicationVersionSetCommand = "application-version-set"
 )
 
-func SetApplicationVersion(version string) error {
-	commandRunner := GetRunner()
+func SetAppVersion(version string) error {
+	commandRunner := GetCommandRunner()
 
 	args := []string{}
 	if version != "" {

--- a/application_version_test.go
+++ b/application_version_test.go
@@ -12,11 +12,11 @@ func TestApplicationVersionSet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	version := "1.2.3"
 
-	err := goops.SetApplicationVersion(version)
+	err := goops.SetAppVersion(version)
 	if err != nil {
 		t.Fatalf("ApplicationVersionSet returned an error: %v", err)
 	}

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -35,3 +35,10 @@ provides:
 actions:
   get-ca-certificate:
     description: Outputs the CA cert
+    params:
+      accept-tos:
+        type: boolean
+        default: false
+        description: >-
+          Do you accept the terms of service?
+    required: [accept-tos]

--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package goops
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -10,20 +9,14 @@ const (
 	configGetCommand = "config-get"
 )
 
-var ErrConfigNotSet = errors.New("config option not set")
-
 func GetConfig(config any) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"--all", "--format=json"}
 
 	output, err := commandRunner.Run(configGetCommand, args...)
 	if err != nil {
 		return fmt.Errorf("failed to get config: %w", err)
-	}
-
-	if len(output) == 0 {
-		return ErrConfigNotSet
 	}
 
 	err = json.Unmarshal(output, config)

--- a/config_test.go
+++ b/config_test.go
@@ -18,7 +18,7 @@ func TestGetConfigSuccess(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	var dat MyConfig
 
@@ -46,7 +46,7 @@ func TestGetConfigFailure(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	var dat MyConfig
 

--- a/credential.go
+++ b/credential.go
@@ -7,7 +7,7 @@ const (
 )
 
 func GetCredential() (map[string]string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"--format=json"}
 

--- a/credential_test.go
+++ b/credential_test.go
@@ -12,7 +12,7 @@ func TestCredentialGet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	result, err := goops.GetCredential()
 	if err != nil {

--- a/env.go
+++ b/env.go
@@ -48,16 +48,16 @@ type JujuEnvironment struct {
 	Getter EnvironmentGetter
 }
 
-func GetEnvironment() EnvironmentGetter {
+func GetEnvGetter() EnvironmentGetter {
 	return defaultGetter
 }
 
-func SetEnvironment(envGetter EnvironmentGetter) {
+func SetEnvGetter(envGetter EnvironmentGetter) {
 	defaultGetter = envGetter
 }
 
 func ReadEnv() Environment {
-	envGetter := GetEnvironment()
+	envGetter := GetEnvGetter()
 
 	return Environment{
 		ActionName:         envGetter.Get("JUJU_ACTION_NAME"),

--- a/goal_state.go
+++ b/goal_state.go
@@ -22,7 +22,7 @@ type GoalState struct {
 }
 
 func GetGoalState() (*GoalState, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"--format=json"}
 

--- a/goal_state_test.go
+++ b/goal_state_test.go
@@ -12,7 +12,7 @@ func TestGoalState_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	expectedGoalState := goops.GoalState{
 		Units: map[string]*goops.UnitStatus{

--- a/goopstest/action_test.go
+++ b/goopstest/action_test.go
@@ -1,6 +1,7 @@
 package goopstest_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gruyaume/goops"
@@ -162,15 +163,21 @@ func TestCharmActionFailed(t *testing.T) {
 	}
 }
 
+type ExampleActionParams struct {
+	WhateverKey string `json:"whatever-key"`
+}
+
 func ActionParameters() error {
-	params, err := goops.GetActionParameter("key")
+	actionParams := ExampleActionParams{}
+
+	err := goops.GetActionParams(&actionParams)
 	if err != nil {
-		_ = goops.FailActionf("Action parameter 'key' not set")
+		_ = goops.FailActionf("couldn't get action parameters: %v", err)
 		return nil
 	}
 
-	if params != "expected-value" {
-		_ = goops.FailActionf("got ActionParameter[key]=%s, want expected-value", params)
+	if actionParams.WhateverKey != "expected-value" {
+		_ = goops.FailActionf("Action parameter 'whatever-key' not set")
 		return nil
 	}
 
@@ -192,7 +199,7 @@ func TestCharmActionParameters(t *testing.T) {
 	stateIn := &goopstest.State{}
 
 	_, err := ctx.RunAction("run-action", stateIn, map[string]string{
-		"key": "expected-value",
+		"whatever-key": "expected-value",
 	})
 	if err != nil {
 		t.Fatalf("Run returned an error: %v", err)
@@ -215,8 +222,14 @@ func TestCharmActionParameterNotSet(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", err)
 	}
 
-	if ctx.ActionError == nil || ctx.ActionError.Error() != "Action parameter 'key' not set" {
-		t.Errorf("got ActionError=%q, want 'Action parameter 'key' not set'", ctx.ActionError.Error())
+	if ctx.ActionError == nil {
+		t.Fatal("Expected ActionError to be set, got nil")
+	}
+
+	fmt.Println("ActionError:", ctx.ActionError.Error())
+
+	if ctx.ActionError.Error() != "Action parameter 'whatever-key' not set" {
+		t.Errorf("got ActionError=%q, want 'Action parameter 'whatever-key' not set'", ctx.ActionError.Error())
 	}
 
 	if ctx.ActionResults != nil {

--- a/goopstest/application_version_test.go
+++ b/goopstest/application_version_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ApplicationVersion() error {
-	err := goops.SetApplicationVersion("1.2.3")
+	err := goops.SetAppVersion("1.2.3")
 	if err != nil {
 		return err
 	}

--- a/goopstest/goopstest.go
+++ b/goopstest/goopstest.go
@@ -661,8 +661,8 @@ func (c *Context) Run(hookName string, state *State) (*State, error) {
 		JujuVersion: c.JujuVersion,
 	}
 
-	goops.SetRunner(fakeRunner)
-	goops.SetEnvironment(fakeGetter)
+	goops.SetCommandRunner(fakeRunner)
+	goops.SetEnvGetter(fakeGetter)
 
 	err := c.Charm()
 	if err != nil {
@@ -705,8 +705,8 @@ func (c *Context) RunAction(actionName string, state *State, params map[string]s
 		JujuVersion: c.JujuVersion,
 	}
 
-	goops.SetRunner(fakeRunner)
-	goops.SetEnvironment(fakeGetter)
+	goops.SetCommandRunner(fakeRunner)
+	goops.SetEnvGetter(fakeGetter)
 
 	err := c.Charm()
 	if err != nil {

--- a/goopstest/goopstest.go
+++ b/goopstest/goopstest.go
@@ -558,21 +558,18 @@ func (f *fakeRunner) handleActionFail(args []string) {
 	f.ActionError = fmt.Errorf("%s", strings.Join(args, " "))
 }
 
-func (f *fakeRunner) handleActionGet(args []string) {
-	key := args[0]
-
-	if value, ok := f.ActionParameters[key]; ok {
-		output, err := json.Marshal(value)
-		if err != nil {
-			f.Err = fmt.Errorf("failed to marshal action parameter: %w", err)
-			return
-		}
-
-		f.Output = output
-	} else {
-		f.Err = fmt.Errorf("action parameter %s not found", key)
-		f.Output = []byte(`""`)
+func (f *fakeRunner) handleActionGet(_ []string) {
+	if f.ActionParameters == nil {
+		f.ActionParameters = make(map[string]string)
 	}
+
+	output, err := json.Marshal(f.ActionParameters)
+	if err != nil {
+		f.Err = fmt.Errorf("failed to marshal action parameters: %w", err)
+		return
+	}
+
+	f.Output = output
 }
 
 func (f *fakeRunner) handleApplicationVersionSet(args []string) {

--- a/internal/charm/actions.go
+++ b/internal/charm/actions.go
@@ -6,7 +6,27 @@ import (
 	"github.com/gruyaume/goops"
 )
 
+type GetCACertificateActionParams struct {
+	AcceptTOS bool `json:"accept-tos"`
+}
+
 func HandleGetCACertificateAction() error {
+	getCAActionParams := GetCACertificateActionParams{}
+
+	err := goops.GetActionParams(&getCAActionParams)
+	if err != nil {
+		return fmt.Errorf("could not get action parameter 'accept-tos': %w", err)
+	}
+
+	if !getCAActionParams.AcceptTOS {
+		err := goops.FailActionf("You must accept the terms of service to get the CA certificate")
+		if err != nil {
+			return fmt.Errorf("could not fail action: %w and could not get action parameter 'accept-tos': %w", err, err)
+		}
+
+		return fmt.Errorf("you must accept the terms of service to get the CA certificate")
+	}
+
 	caCertificateSecret, err := goops.GetSecretByLabel(CaCertificateSecretLabel, false, true)
 	if err != nil {
 		err := goops.FailActionf("could not get CA certificate secret")

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -323,7 +323,7 @@ func Configure() error {
 		return fmt.Errorf("could not validate state: %w", err)
 	}
 
-	err = goops.SetApplicationVersion("1.0.0")
+	err = goops.SetAppVersion("1.0.0")
 	if err != nil {
 		return fmt.Errorf("could not set application version using goops: %w", err)
 	}

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -153,38 +153,28 @@ func setPorts() error {
 }
 
 func validateNetworkGet() error {
-	bindAddress, err := goops.GetNetworkBindAddress("certificates")
+	network, err := goops.GetNetwork("certificates")
 	if err != nil {
 		return fmt.Errorf("could not get network config: %w", err)
 	}
 
-	if bindAddress == "" {
+	if network.BindAddresses[0].Addresses[0].Value == "" {
 		return fmt.Errorf("network config bind addresses is empty")
 	}
 
-	goops.LogInfof("Bind address: %s", bindAddress)
+	goops.LogInfof("Bind address: %s", network.BindAddresses[0].Addresses[0].Value)
 
-	ingressAddress, err := goops.GetNetworkIngressAddress("certificates")
-	if err != nil {
-		return fmt.Errorf("could not get network ingress addresses: %w", err)
-	}
-
-	if ingressAddress == "" {
+	if network.IngressAddresses[0] == "" {
 		return fmt.Errorf("network config ingress address is empty")
 	}
 
-	goops.LogInfof("Ingress address: %s", ingressAddress)
+	goops.LogInfof("Ingress address: %s", network.IngressAddresses[0])
 
-	egressSubnets, err := goops.GetNetworkEgressSubnets("certificates")
-	if err != nil {
-		return fmt.Errorf("could not get network egress subnets: %w", err)
-	}
-
-	if len(egressSubnets) == 0 {
+	if len(network.EgressSubnets[0]) == 0 {
 		return fmt.Errorf("network config egress subnets is empty")
 	}
 
-	if egressSubnets[0] == "" {
+	if network.EgressSubnets[0] == "" {
 		return fmt.Errorf("network config egress subnet is empty")
 	}
 

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -40,6 +40,8 @@ func generateAndStoreRootCertificate() error {
 		return fmt.Errorf("could not get config: %w", err)
 	}
 
+	goops.LogInfof("Generating root certificate with common name: %s", configOpts.CACommonName)
+
 	_, err = goops.GetSecretByLabel(CaCertificateSecretLabel, false, true)
 	if err != nil {
 		goops.LogInfof("could not get secret: %s", err.Error())

--- a/leader.go
+++ b/leader.go
@@ -10,7 +10,7 @@ const (
 )
 
 func IsLeader() (bool, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"--format=json"}
 

--- a/leader_test.go
+++ b/leader_test.go
@@ -12,7 +12,7 @@ func TestIsLeader_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	result, err := goops.IsLeader()
 	if err != nil {

--- a/logging.go
+++ b/logging.go
@@ -24,7 +24,7 @@ var levelStrings = []string{
 }
 
 func logf(level Level, format string, args ...any) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	message := fmt.Sprintf(format, args...)
 

--- a/logging_test.go
+++ b/logging_test.go
@@ -12,7 +12,7 @@ func TestJujuLogStatusSet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	goops.LogDebugf("my message")
 

--- a/network.go
+++ b/network.go
@@ -25,45 +25,12 @@ type Network struct {
 	EgressSubnets    []string      `json:"egress-subnets"`
 }
 
-type NetworkGetOptions struct {
-	BindingName    string
-	BindAddress    bool
-	EgressSubnets  bool
-	IngressAddress bool
-	PrimaryAddress bool
-	Relation       string
-}
-
-func GetNetwork(opts *NetworkGetOptions) (*Network, error) {
+func GetNetwork(bindingName string) (*Network, error) {
 	commandRunner := GetCommandRunner()
 
 	var args []string
 
-	if opts.BindingName == "" {
-		return nil, fmt.Errorf("binding name cannot be empty")
-	}
-
-	if opts.BindAddress {
-		args = append(args, "--bind-address")
-	}
-
-	if opts.EgressSubnets {
-		args = append(args, "--egress-subnets")
-	}
-
-	if opts.IngressAddress {
-		args = append(args, "--ingress-address")
-	}
-
-	if opts.PrimaryAddress {
-		args = append(args, "--primary-address")
-	}
-
-	if opts.Relation != "" {
-		args = append(args, "--relation="+opts.Relation)
-	}
-
-	args = append(args, opts.BindingName, "--format=json")
+	args = append(args, bindingName, "--format=json")
 
 	output, err := commandRunner.Run(networkGetCommand, args...)
 	if err != nil {
@@ -78,84 +45,4 @@ func GetNetwork(opts *NetworkGetOptions) (*Network, error) {
 	}
 
 	return &network, nil
-}
-
-func GetNetworkBindAddress(bindingName string) (string, error) {
-	commandRunner := GetCommandRunner()
-
-	var args []string
-
-	args = append(args, "--bind-address")
-
-	args = append(args, bindingName, "--format=json")
-
-	output, err := commandRunner.Run(networkGetCommand, args...)
-	if err != nil {
-		return "", err
-	}
-
-	var bindAddress string
-
-	err = json.Unmarshal(output, &bindAddress)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse network data: %w", err)
-	}
-
-	return bindAddress, nil
-}
-
-func GetNetworkIngressAddress(bindingName string) (string, error) {
-	commandRunner := GetCommandRunner()
-
-	var args []string
-
-	if bindingName == "" {
-		return "", fmt.Errorf("binding name cannot be empty")
-	}
-
-	args = append(args, "--ingress-address")
-
-	args = append(args, bindingName, "--format=json")
-
-	output, err := commandRunner.Run(networkGetCommand, args...)
-	if err != nil {
-		return "", err
-	}
-
-	var ingressAddress string
-
-	err = json.Unmarshal(output, &ingressAddress)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse network data: %w", err)
-	}
-
-	return ingressAddress, nil
-}
-
-func GetNetworkEgressSubnets(bindingName string) ([]string, error) {
-	commandRunner := GetCommandRunner()
-
-	var args []string
-
-	if bindingName == "" {
-		return nil, fmt.Errorf("binding name cannot be empty")
-	}
-
-	args = append(args, "--egress-subnets")
-
-	args = append(args, bindingName, "--format=json")
-
-	output, err := commandRunner.Run(networkGetCommand, args...)
-	if err != nil {
-		return nil, err
-	}
-
-	var egressSubnets []string
-
-	err = json.Unmarshal(output, &egressSubnets)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse network data: %w", err)
-	}
-
-	return egressSubnets, nil
 }

--- a/network.go
+++ b/network.go
@@ -35,7 +35,7 @@ type NetworkGetOptions struct {
 }
 
 func GetNetwork(opts *NetworkGetOptions) (*Network, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	var args []string
 
@@ -81,7 +81,7 @@ func GetNetwork(opts *NetworkGetOptions) (*Network, error) {
 }
 
 func GetNetworkBindAddress(bindingName string) (string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	var args []string
 
@@ -105,7 +105,7 @@ func GetNetworkBindAddress(bindingName string) (string, error) {
 }
 
 func GetNetworkIngressAddress(bindingName string) (string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	var args []string
 
@@ -133,7 +133,7 @@ func GetNetworkIngressAddress(bindingName string) (string, error) {
 }
 
 func GetNetworkEgressSubnets(bindingName string) ([]string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	var args []string
 

--- a/network_test.go
+++ b/network_test.go
@@ -14,11 +14,7 @@ func TestNetworkGet_Success(t *testing.T) {
 
 	goops.SetCommandRunner(fakeRunner)
 
-	networkGetOptions := &goops.NetworkGetOptions{
-		BindingName: "whatever",
-	}
-
-	result, err := goops.GetNetwork(networkGetOptions)
+	result, err := goops.GetNetwork("whatever")
 	if err != nil {
 		t.Fatalf("NetworkGet returned an error: %v", err)
 	}

--- a/network_test.go
+++ b/network_test.go
@@ -12,7 +12,7 @@ func TestNetworkGet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	networkGetOptions := &goops.NetworkGetOptions{
 		BindingName: "whatever",

--- a/ports.go
+++ b/ports.go
@@ -58,7 +58,7 @@ func SetPorts(ports []*Port) error {
 }
 
 func OpenPort(port int, protocol string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	if port < 0 || port > 65535 {
 		return fmt.Errorf("port %d is out of range", port)
@@ -79,7 +79,7 @@ func OpenPort(port int, protocol string) error {
 }
 
 func ClosePort(port int, protocol string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	if port < 0 || port > 65535 {
 		return fmt.Errorf("port %d is out of range", port)
@@ -100,7 +100,7 @@ func ClosePort(port int, protocol string) error {
 }
 
 func OpenedPorts() ([]*Port, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"--format=json"}
 

--- a/ports_test.go
+++ b/ports_test.go
@@ -12,7 +12,7 @@ func TestOpenPortTCP_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.OpenPort(80, "tcp")
 	if err != nil {
@@ -38,7 +38,7 @@ func TestOpenPortUDP_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.OpenPort(80, "udp")
 	if err != nil {
@@ -64,7 +64,7 @@ func TestOpenPortInvalidPort_Failure(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.OpenPort(-1, "tcp")
 	if err == nil {
@@ -86,7 +86,7 @@ func TestOpenPortInvalidProtocol_Failure(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.OpenPort(80, "invalid")
 	if err == nil {
@@ -108,7 +108,7 @@ func TestClosePortTCP_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.ClosePort(80, "tcp")
 	if err != nil {
@@ -134,7 +134,7 @@ func TestClosePortUDP_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.ClosePort(80, "udp")
 	if err != nil {
@@ -160,7 +160,7 @@ func TestClosePortInvalidPort_Failure(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.ClosePort(-1, "tcp")
 	if err == nil {
@@ -182,7 +182,7 @@ func TestClosePortInvalidProtocol_Failure(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.ClosePort(80, "invalid")
 	if err == nil {

--- a/reboot.go
+++ b/reboot.go
@@ -5,7 +5,7 @@ const (
 )
 
 func Reboot(now bool) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	var args []string
 	if now {

--- a/reboot_test.go
+++ b/reboot_test.go
@@ -12,7 +12,7 @@ func TestJujuReboot_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.Reboot(true)
 	if err != nil {

--- a/relations.go
+++ b/relations.go
@@ -14,7 +14,7 @@ const (
 )
 
 func GetRelationIDs(name string) ([]string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{name, "--format=json"}
 
@@ -34,7 +34,7 @@ func GetRelationIDs(name string) ([]string, error) {
 }
 
 func GetUnitRelationData(id string, unitID string) (map[string]string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"-r=" + id, "-", unitID}
 
@@ -56,7 +56,7 @@ func GetUnitRelationData(id string, unitID string) (map[string]string, error) {
 }
 
 func GetAppRelationData(id string, unitID string) (map[string]string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"-r=" + id, "-", unitID, "--app"}
 
@@ -78,7 +78,7 @@ func GetAppRelationData(id string, unitID string) (map[string]string, error) {
 }
 
 func ListRelationUnits(id string) ([]string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"-r=" + id, "--format=json"}
 
@@ -98,7 +98,7 @@ func ListRelationUnits(id string) ([]string, error) {
 }
 
 func GetRelationApp(id string) (string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"-r=" + id, "--app", "--format=json"}
 
@@ -118,7 +118,7 @@ func GetRelationApp(id string) (string, error) {
 }
 
 func SetUnitRelationData(id string, data map[string]string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"-r=" + id}
 
@@ -139,7 +139,7 @@ func SetUnitRelationData(id string, data map[string]string) error {
 }
 
 func SetAppRelationData(id string, data map[string]string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"-r=" + id}
 
@@ -166,7 +166,7 @@ type RelationModel struct {
 }
 
 func GetRelationModel(id string) (string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"-r=" + id, "--format=json"}
 

--- a/relations_test.go
+++ b/relations_test.go
@@ -12,7 +12,7 @@ func TestRelationIDs_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	result, err := goops.GetRelationIDs("tls-certificates")
 	if err != nil {
@@ -56,7 +56,7 @@ func TestRelationGet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	result, err := goops.GetUnitRelationData("certificates:0", "tls-certificates-requirer/0")
 	if err != nil {
@@ -108,7 +108,7 @@ func TestListRelationUnits_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	result, err := goops.ListRelationUnits("certificates:0")
 	if err != nil {
@@ -148,7 +148,7 @@ func TestGetRelationApp_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	app, err := goops.GetRelationApp("certificates:0")
 	if err != nil {
@@ -176,7 +176,7 @@ func TestRelationSet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.SetAppRelationData("certificates:0", map[string]string{
 		"username": "user1",
@@ -217,7 +217,7 @@ func TestRelationModelGet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	uuid, err := goops.GetRelationModel("certificates:0")
 	if err != nil {

--- a/resource.go
+++ b/resource.go
@@ -4,12 +4,8 @@ const (
 	resourceGetCommand = "resource-get"
 )
 
-type ResourceGetOptions struct {
-	Name string
-}
-
 func GetResource(name string) (string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{name}
 

--- a/resource_test.go
+++ b/resource_test.go
@@ -12,7 +12,7 @@ func TestResourceGet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	result, err := goops.GetResource("software")
 	if err != nil {

--- a/runner.go
+++ b/runner.go
@@ -35,10 +35,10 @@ type CommandRunner interface {
 	Run(name string, args ...string) ([]byte, error)
 }
 
-func GetRunner() CommandRunner {
+func GetCommandRunner() CommandRunner {
 	return defaultRunner
 }
 
-func SetRunner(runner CommandRunner) {
+func SetCommandRunner(runner CommandRunner) {
 	defaultRunner = runner
 }

--- a/secrets.go
+++ b/secrets.go
@@ -53,7 +53,7 @@ type AddSecretOptions struct {
 }
 
 func AddSecret(opts *AddSecretOptions) (string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	if len(opts.Content) == 0 {
 		return "", fmt.Errorf("content cannot be empty")
@@ -93,7 +93,7 @@ func AddSecret(opts *AddSecretOptions) (string, error) {
 }
 
 func GetSecretByID(id string, peek bool, refresh bool) (map[string]string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	var args []string
 	args = append(args, id)
@@ -124,7 +124,7 @@ func GetSecretByID(id string, peek bool, refresh bool) (map[string]string, error
 }
 
 func GetSecretByLabel(label string, peek bool, refresh bool) (map[string]string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	var args []string
 
@@ -156,7 +156,7 @@ func GetSecretByLabel(label string, peek bool, refresh bool) (map[string]string,
 }
 
 func GrantSecretToRelation(id string, relation string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{id, "--relation=" + relation}
 
@@ -169,7 +169,7 @@ func GrantSecretToRelation(id string, relation string) error {
 }
 
 func GrantSecretToUnit(id string, relation string, unit string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{id, "--relation=" + relation, "--unit=" + unit}
 
@@ -182,7 +182,7 @@ func GrantSecretToUnit(id string, relation string, unit string) error {
 }
 
 func GetSecretIDs() ([]string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	output, err := commandRunner.Run(secredIDsCommand, "--format=json")
 	if err != nil {
@@ -200,7 +200,7 @@ func GetSecretIDs() ([]string, error) {
 }
 
 func GetSecretInfoByID(id string) (map[string]SecretInfo, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{}
 
@@ -228,7 +228,7 @@ func GetSecretInfoByID(id string) (map[string]SecretInfo, error) {
 }
 
 func GetSecretInfoByLabel(label string) (map[string]SecretInfo, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{}
 
@@ -256,7 +256,7 @@ func GetSecretInfoByLabel(label string) (map[string]SecretInfo, error) {
 }
 
 func RemoveSecret(id string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{id}
 
@@ -276,7 +276,7 @@ type RevokeSecretOptions struct {
 }
 
 func RevokeSecret(id string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{id}
 
@@ -289,7 +289,7 @@ func RevokeSecret(id string) error {
 }
 
 func RevokeSecretFromRelation(id string, relation string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{id}
 
@@ -304,7 +304,7 @@ func RevokeSecretFromRelation(id string, relation string) error {
 }
 
 func RevokeSecretFromApp(id string, app string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{id}
 
@@ -319,7 +319,7 @@ func RevokeSecretFromApp(id string, app string) error {
 }
 
 func RevokeSecretFromUnit(id string, unit string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{id}
 
@@ -334,7 +334,7 @@ func RevokeSecretFromUnit(id string, unit string) error {
 }
 
 func SetSecret(opts *SetSecretOptions) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	if opts.ID == "" {
 		return fmt.Errorf("secret ID cannot be empty")

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -13,7 +13,7 @@ func TestSecretIDs_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	result, err := goops.GetSecretIDs()
 	if err != nil {
@@ -53,7 +53,7 @@ func TestSecretGet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	result, err := goops.GetSecretByLabel("my-label", false, true)
 	if err != nil {
@@ -108,7 +108,7 @@ func TestSecretAdd_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	expiry := time.Now().Add(24 * time.Hour)
 
@@ -170,7 +170,7 @@ func TestSecretAdd_EmptyContent(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	secretAddOptions := &goops.AddSecretOptions{
 		Description: "my secret",
@@ -191,7 +191,7 @@ func TestSecretGrant_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.GrantSecretToRelation("123", "certificates:0")
 	if err != nil {
@@ -221,7 +221,7 @@ func TestSecretInfoGet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	secretInfo, err := goops.GetSecretInfoByLabel("my-secret-label")
 	if err != nil {
@@ -279,7 +279,7 @@ func TestSecretRemove_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.RemoveSecret("123")
 	if err != nil {
@@ -301,7 +301,7 @@ func TestSecretRevoke_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.RevokeSecret("123")
 	if err != nil {
@@ -323,7 +323,7 @@ func TestSecretSet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	secretContent := map[string]string{
 		"username": "user1",

--- a/state.go
+++ b/state.go
@@ -12,7 +12,7 @@ const (
 )
 
 func DeleteState(key string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{key}
 
@@ -29,7 +29,7 @@ func DeleteState(key string) error {
 }
 
 func GetState(key string) (string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{key, "--format=json"}
 
@@ -53,7 +53,7 @@ func GetState(key string) (string, error) {
 }
 
 func SetState(key string, value string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{key + "=" + value}
 

--- a/state_test.go
+++ b/state_test.go
@@ -12,7 +12,7 @@ func TestStateDelete_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.DeleteState("key")
 	if err != nil {
@@ -38,7 +38,7 @@ func TestStateGet_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	state, err := goops.GetState("key")
 	if err != nil {

--- a/status.go
+++ b/status.go
@@ -25,7 +25,7 @@ type Status struct {
 }
 
 func SetUnitStatus(status StatusCode, message ...string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	var args []string
 
@@ -44,7 +44,7 @@ func SetUnitStatus(status StatusCode, message ...string) error {
 }
 
 func SetAppStatus(status StatusCode, message ...string) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	var args []string
 
@@ -63,7 +63,7 @@ func SetAppStatus(status StatusCode, message ...string) error {
 }
 
 func GetUnitStatus() (*Status, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"--include-data", "--format=json"}
 
@@ -83,7 +83,7 @@ func GetUnitStatus() (*Status, error) {
 }
 
 func GetAppStatus() (*Status, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"--application", "--include-data", "--format=json"}
 

--- a/status_test.go
+++ b/status_test.go
@@ -12,7 +12,7 @@ func TestSetUnitStatus_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.SetUnitStatus(goops.StatusActive)
 	if err != nil {
@@ -42,7 +42,7 @@ func TestSetAppStatus_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.SetAppStatus(goops.StatusActive)
 	if err != nil {
@@ -76,7 +76,7 @@ func TestGetUnitStatus_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	status, err := goops.GetUnitStatus()
 	if err != nil {
@@ -114,7 +114,7 @@ func TestGetAppStatus_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	status, err := goops.GetAppStatus()
 	if err != nil {

--- a/storage.go
+++ b/storage.go
@@ -12,7 +12,7 @@ const (
 )
 
 func AddStorage(name string, count int) error {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{}
 
@@ -27,7 +27,7 @@ func AddStorage(name string, count int) error {
 }
 
 func GetStorageByID(id string) (string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{id}
 
@@ -49,7 +49,7 @@ func GetStorageByID(id string) (string, error) {
 }
 
 func GetStorageByName(name string) (string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{"-s", name}
 
@@ -71,7 +71,7 @@ func GetStorageByName(name string) (string, error) {
 }
 
 func ListStorage(name string) ([]string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{name, "--format=json"}
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -12,7 +12,7 @@ func TestStorageAdd_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.AddStorage("database-storage", 1)
 	if err != nil {
@@ -38,7 +38,7 @@ func TestStorageAddWithCount_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	err := goops.AddStorage("database-storage", 2)
 	if err != nil {
@@ -64,7 +64,7 @@ func TestStorageGetByName_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	storage, err := goops.GetStorageByName("database-storage")
 	if err != nil {
@@ -102,7 +102,7 @@ func TestStorageGetByID_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	storage, err := goops.GetStorageByID("21127934-8986-11e5-af63-feff819cdc9f")
 	if err != nil {
@@ -136,7 +136,7 @@ func TestStorageList_Success(t *testing.T) {
 		Err:    nil,
 	}
 
-	goops.SetRunner(fakeRunner)
+	goops.SetCommandRunner(fakeRunner)
 
 	storage, err := goops.ListStorage("database-storage")
 	if err != nil {

--- a/unit.go
+++ b/unit.go
@@ -10,7 +10,7 @@ const (
 )
 
 func getUnit(key string) (string, error) {
-	commandRunner := GetRunner()
+	commandRunner := GetCommandRunner()
 
 	args := []string{key}
 


### PR DESCRIPTION
# Description

- As requested in #34, here we rename functions:
  - `SetApplicationVersion` -> `SetAppVersion`
  - `GetEnvironment` / `SetEnvironment` -> `GetEnvGetter` / `SetEnvGetter`
  - `LogActionf` -> `ActionLogf`
- We remove the unused `ResourceGetOptions` type
- We simplify network related by only keeping a `func GetNetwork(bindingName string) (*Network, error) {}` and removing all other network get functions.
- Use unmarshalling pattern for action params

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
