### PR TITLE
feat: allow any type in action param struct [goopstest]

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -25,6 +25,7 @@ func FailActionf(format string, args ...any) error {
 	return nil
 }
 
+// GetActionParams retrieves the parameters for the current action and unmarshals them into the provided params struct.
 func GetActionParams(params any) error {
 	commandRunner := GetCommandRunner()
 

--- a/actions.go
+++ b/actions.go
@@ -12,6 +12,8 @@ const (
 	actionSetCommand  = "action-set"
 )
 
+// FailActionf fails the current action with a formatted message.
+// This functionality only works when the charm is running in an action hook.
 func FailActionf(format string, args ...any) error {
 	commandRunner := GetCommandRunner()
 
@@ -26,6 +28,7 @@ func FailActionf(format string, args ...any) error {
 }
 
 // GetActionParams retrieves the parameters for the current action and unmarshals them into the provided params struct.
+// This functionality only works when the charm is running in an action hook.
 func GetActionParams(params any) error {
 	commandRunner := GetCommandRunner()
 
@@ -45,6 +48,7 @@ func GetActionParams(params any) error {
 }
 
 // ActionLogf records a progress message for the current action.
+// This functionality only works when the charm is running in an action hook.
 func ActionLogf(format string, args ...any) error {
 	commandRunner := GetCommandRunner()
 
@@ -58,6 +62,8 @@ func ActionLogf(format string, args ...any) error {
 	return nil
 }
 
+// SetActionResults sets action results.
+// This functionality only works when the charm is running in an action hook.
 func SetActionResults(results map[string]string) error {
 	commandRunner := GetCommandRunner()
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -41,4 +41,9 @@ actions:
         default: false
         description: >-
           Do you accept the terms of service?
+      email:
+        type: string
+        description: >-
+          Email address to be used for the CA certificate.
+          This is optional, but recommended.
     required: [accept-tos]

--- a/goopstest/action_test.go
+++ b/goopstest/action_test.go
@@ -168,7 +168,7 @@ type ExampleActionParams struct {
 	AcceptTOS bool   `json:"accept-tos"`
 }
 
-func ActionParameters() error {
+func GetActionParamsAndSetResults() error {
 	actionParams := ExampleActionParams{}
 
 	err := goops.GetActionParams(&actionParams)
@@ -199,7 +199,7 @@ func ActionParameters() error {
 
 func TestCharmActionParameters(t *testing.T) {
 	ctx := goopstest.Context{
-		Charm: ActionParameters,
+		Charm: GetActionParamsAndSetResults,
 	}
 
 	stateIn := &goopstest.State{}
@@ -219,7 +219,7 @@ func TestCharmActionParameters(t *testing.T) {
 
 func TestCharmActionParameterNotSet(t *testing.T) {
 	ctx := goopstest.Context{
-		Charm: ActionParameters,
+		Charm: GetActionParamsAndSetResults,
 	}
 
 	stateIn := &goopstest.State{}
@@ -242,7 +242,7 @@ func TestCharmActionParameterNotSet(t *testing.T) {
 	}
 }
 
-func ActionParameters2() error {
+func ActionParams() error {
 	actionParams := ExampleActionParams{}
 
 	err := goops.GetActionParams(&actionParams)
@@ -255,7 +255,7 @@ func ActionParameters2() error {
 
 func TestGetActionParamInNonActionHook(t *testing.T) {
 	ctx := goopstest.Context{
-		Charm: ActionParameters2,
+		Charm: ActionParams,
 	}
 
 	stateIn := &goopstest.State{}
@@ -271,5 +271,99 @@ func TestGetActionParamInNonActionHook(t *testing.T) {
 
 	if ctx.CharmErr.Error() != "couldn't get action parameters: failed to get action parameter: command action-get failed: ERROR not running an action" {
 		t.Errorf("got CharmErr=%q, want 'couldn't get action parameters: failed to get action parameter: command action-get failed: ERROR not running an action'", ctx.CharmErr.Error())
+	}
+}
+
+func ActionFailf() error {
+	err := goops.FailActionf("whatever message")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestActionFailfInNonActionHook(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: ActionFailf,
+	}
+
+	stateIn := &goopstest.State{}
+
+	_, err := ctx.Run("start", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if ctx.CharmErr == nil {
+		t.Fatal("Expected CharmErr to be set, got nil")
+	}
+
+	if ctx.CharmErr.Error() != "failed to fail action: command action-fail failed: ERROR not running an action" {
+		t.Errorf("got CharmErr=%q, want 'failed to fail action: command action-fail failed: ERROR not running an action'", ctx.CharmErr.Error())
+	}
+}
+
+func ActionLogf() error {
+	err := goops.ActionLogf("This is a log message from the action")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestActionLogfInNonActionHook(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: ActionLogf,
+	}
+
+	stateIn := &goopstest.State{}
+
+	_, err := ctx.Run("start", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if ctx.CharmErr == nil {
+		t.Fatal("Expected CharmErr to be set, got nil")
+	}
+
+	if ctx.CharmErr.Error() != "failed to log action message: command action-log failed: ERROR not running an action" {
+		t.Errorf("got CharmErr=%q, want 'failed to log action message: command action-log failed: ERROR not running an action'", ctx.CharmErr.Error())
+	}
+}
+
+func SetActionResults() error {
+	results := map[string]string{
+		"key": "value",
+	}
+
+	err := goops.SetActionResults(results)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestSetActionResultsInNonActionHook(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: SetActionResults,
+	}
+
+	stateIn := &goopstest.State{}
+
+	_, err := ctx.Run("start", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if ctx.CharmErr == nil {
+		t.Fatal("Expected CharmErr to be set, got nil")
+	}
+
+	if ctx.CharmErr.Error() != "failed to set action parameters: command action-set failed: ERROR not running an action" {
+		t.Errorf("got CharmErr=%q, want 'failed to set action parameters: command action-set failed: ERROR not running an action'", ctx.CharmErr.Error())
 	}
 }

--- a/goopstest/goopstest.go
+++ b/goopstest/goopstest.go
@@ -68,6 +68,7 @@ func (f *fakeCommandRunner) Run(name string, args ...string) ([]byte, error) {
 		"action-fail":             f.handleActionFail,
 		"action-get":              f.handleActionGet,
 		"action-set":              f.handleActionSet,
+		"action-log":              f.handleActionLog,
 		"application-version-set": f.handleApplicationVersionSet,
 		"config-get":              f.handleConfigGet,
 		"is-leader":               f.handleIsLeader,
@@ -642,10 +643,27 @@ func parseKeyValueArgs(args []string) map[string]string {
 }
 
 func (f *fakeCommandRunner) handleActionSet(args []string) {
+	if goops.ReadEnv().ActionName == "" {
+		f.Err = fmt.Errorf("command action-set failed: ERROR not running an action")
+		return
+	}
+
 	f.ActionResults = parseKeyValueArgs(args)
 }
 
+func (f *fakeCommandRunner) handleActionLog(_ []string) {
+	if goops.ReadEnv().ActionName == "" {
+		f.Err = fmt.Errorf("command action-log failed: ERROR not running an action")
+		return
+	}
+}
+
 func (f *fakeCommandRunner) handleActionFail(args []string) {
+	if goops.ReadEnv().ActionName == "" {
+		f.Err = fmt.Errorf("command action-fail failed: ERROR not running an action")
+		return
+	}
+
 	f.ActionError = fmt.Errorf("%s", strings.Join(args, " "))
 }
 


### PR DESCRIPTION
# Description

Adapt goopstest action handlers to real Juju behavior:

- Error out on non action related events
- Improve goops API documentation
- Allow any type in action parameters

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
