### PR TITLE
feat: capture status message [goopstest]

### DIFF
--- a/goopstest/README.md
+++ b/goopstest/README.md
@@ -52,8 +52,13 @@ func TestCharm(t *testing.T) {
 	}
 
 	// Assert
-	if stateOut.UnitStatus != string(goops.StatusBlocked) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goops.StatusBlocked)
+	expectedStatus := goopstest.Status{
+		Name:    goopstest.StatusBlocked,
+		Message: "Unit is not a leader",
+	}
+
+	if stateOut.UnitStatus != expectedStatus {
+		t.Errorf("got Status=%q, want %q", stateOut.UnitStatus, expectedStatus)
 	}
 }
 ```

--- a/goopstest/action_test.go
+++ b/goopstest/action_test.go
@@ -28,22 +28,22 @@ func MaintenanceStatusOnAction() error {
 
 func TestCharmActionName(t *testing.T) {
 	tests := []struct {
-		name       string
-		handler    func() error
-		actionName string
-		want       string
+		name               string
+		handler            func() error
+		actionName         string
+		expectedStatusName goopstest.StatusName
 	}{
 		{
-			name:       "MaintenanceStatusOnAction",
-			handler:    MaintenanceStatusOnAction,
-			actionName: "run-action",
-			want:       string(goops.StatusMaintenance),
+			name:               "MaintenanceStatusOnAction",
+			handler:            MaintenanceStatusOnAction,
+			actionName:         "run-action",
+			expectedStatusName: goopstest.StatusMaintenance,
 		},
 		{
-			name:       "ActiveStatusOnOtherActions",
-			handler:    MaintenanceStatusOnAction,
-			actionName: "something-else",
-			want:       string(goops.StatusActive),
+			name:               "ActiveStatusOnOtherActions",
+			handler:            MaintenanceStatusOnAction,
+			actionName:         "something-else",
+			expectedStatusName: goopstest.StatusActive,
 		},
 	}
 
@@ -60,8 +60,8 @@ func TestCharmActionName(t *testing.T) {
 				t.Fatalf("Run returned an error: %v", err)
 			}
 
-			if stateOut.UnitStatus != tc.want {
-				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.want)
+			if stateOut.UnitStatus.Name != tc.expectedStatusName {
+				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.expectedStatusName)
 			}
 		})
 	}

--- a/goopstest/command_runner.go
+++ b/goopstest/command_runner.go
@@ -15,8 +15,8 @@ type fakeCommandRunner struct {
 	Args               []string
 	Output             []byte
 	Err                error
-	UnitStatus         string
-	AppStatus          string
+	UnitStatus         Status
+	AppStatus          Status
 	Leader             bool
 	Config             map[string]any
 	Secrets            []*Secret
@@ -88,9 +88,15 @@ func (f *fakeCommandRunner) handleStatusSet(args []string) {
 			return
 		}
 
-		f.AppStatus = args[1]
+		f.AppStatus = Status{
+			Name:    StatusName(args[1]),
+			Message: strings.Join(args[2:], " "),
+		}
 	} else {
-		f.UnitStatus = args[0]
+		f.UnitStatus = Status{
+			Name:    StatusName(args[0]),
+			Message: strings.Join(args[1:], " "),
+		}
 	}
 }
 

--- a/goopstest/config_test.go
+++ b/goopstest/config_test.go
@@ -50,36 +50,36 @@ func ActiveInexistantConfig() error {
 
 func TestCharmConfig(t *testing.T) {
 	tests := []struct {
-		name     string
-		handler  func() error
-		hookName string
-		key      string
-		value    string
-		want     string
+		name               string
+		handler            func() error
+		hookName           string
+		key                string
+		value              string
+		expectedStatusName goopstest.StatusName
 	}{
 		{
-			name:     "ActiveIfExpectedConfig",
-			handler:  ActiveIfExpectedConfig,
-			hookName: "start",
-			key:      "whatever_key",
-			value:    "expected",
-			want:     string(goops.StatusActive),
+			name:               "ActiveIfExpectedConfig",
+			handler:            ActiveIfExpectedConfig,
+			hookName:           "start",
+			key:                "whatever_key",
+			value:              "expected",
+			expectedStatusName: goopstest.StatusActive,
 		},
 		{
-			name:     "BlockedIfNotExpectedConfig",
-			handler:  ActiveIfExpectedConfig,
-			hookName: "start",
-			key:      "whatever_key",
-			value:    "not-expected",
-			want:     string(goops.StatusBlocked),
+			name:               "BlockedIfNotExpectedConfig",
+			handler:            ActiveIfExpectedConfig,
+			hookName:           "start",
+			key:                "whatever_key",
+			value:              "not-expected",
+			expectedStatusName: goopstest.StatusBlocked,
 		},
 		{
-			name:     "ActiveInexistantConfig",
-			handler:  ActiveInexistantConfig,
-			hookName: "start",
-			key:      "a-different-key",
-			value:    "whatever",
-			want:     string(goops.StatusBlocked),
+			name:               "ActiveInexistantConfig",
+			handler:            ActiveInexistantConfig,
+			hookName:           "start",
+			key:                "a-different-key",
+			value:              "whatever",
+			expectedStatusName: goopstest.StatusBlocked,
 		},
 	}
 
@@ -106,8 +106,8 @@ func TestCharmConfig(t *testing.T) {
 				t.Errorf("expected no error, got %v", ctx.CharmErr)
 			}
 
-			if stateOut.UnitStatus != tc.want {
-				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.want)
+			if stateOut.UnitStatus.Name != tc.expectedStatusName {
+				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.expectedStatusName)
 			}
 		})
 	}
@@ -131,7 +131,7 @@ func TestActiveIfExpectedConfigInActionHook(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", err)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusActive) {
-		t.Errorf("Expected UnitStatus %q, got %q", goops.StatusActive, stateOut.UnitStatus)
+	if stateOut.UnitStatus.Name != goopstest.StatusActive {
+		t.Errorf("Expected UnitStatus %q, got %q", goopstest.StatusActive, stateOut.UnitStatus)
 	}
 }

--- a/goopstest/docs_test.go
+++ b/goopstest/docs_test.go
@@ -47,8 +47,13 @@ func TestCharmBasic(t *testing.T) {
 	}
 
 	// Assert
-	if stateOut.UnitStatus != string(goops.StatusBlocked) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goops.StatusBlocked)
+	expectedStatus := goopstest.Status{
+		Name:    goopstest.StatusBlocked,
+		Message: "Unit is not a leader",
+	}
+
+	if stateOut.UnitStatus != expectedStatus {
+		t.Errorf("got Status=%q, want %q", stateOut.UnitStatus, expectedStatus)
 	}
 }
 

--- a/goopstest/hook_test.go
+++ b/goopstest/hook_test.go
@@ -43,22 +43,22 @@ func ActiveStatusOnInstall() error {
 
 func TestCharmHookName(t *testing.T) {
 	tests := []struct {
-		name     string
-		handler  func() error
-		hookName string
-		want     string
+		name               string
+		handler            func() error
+		hookName           string
+		expectedStatusName goopstest.StatusName
 	}{
 		{
-			name:     "MaintenanceStatusOnStart",
-			handler:  MaintenanceStatusOnStart,
-			hookName: "start",
-			want:     string(goops.StatusMaintenance),
+			name:               "MaintenanceStatusOnStart",
+			handler:            MaintenanceStatusOnStart,
+			hookName:           "start",
+			expectedStatusName: goopstest.StatusMaintenance,
 		},
 		{
-			name:     "ActiveStatusOnInstall",
-			handler:  ActiveStatusOnInstall,
-			hookName: "install",
-			want:     string(goops.StatusActive),
+			name:               "ActiveStatusOnInstall",
+			handler:            ActiveStatusOnInstall,
+			hookName:           "install",
+			expectedStatusName: goopstest.StatusActive,
 		},
 	}
 
@@ -75,8 +75,8 @@ func TestCharmHookName(t *testing.T) {
 				t.Fatalf("Run returned an error: %v", err)
 			}
 
-			if stateOut.UnitStatus != tc.want {
-				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.want)
+			if stateOut.UnitStatus.Name != tc.expectedStatusName {
+				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.expectedStatusName)
 			}
 		})
 	}

--- a/goopstest/leader_test.go
+++ b/goopstest/leader_test.go
@@ -51,25 +51,25 @@ func MaintenanceStatusIfNotLeader() error {
 
 func TestCharmLeader(t *testing.T) {
 	tests := []struct {
-		name     string
-		handler  func() error
-		hookName string
-		leader   bool
-		want     string
+		name               string
+		handler            func() error
+		hookName           string
+		leader             bool
+		expectedStatusName goopstest.StatusName
 	}{
 		{
-			name:     "MaintenanceStatusIfLeader",
-			handler:  MaintenanceStatusIfLeader,
-			hookName: "start",
-			leader:   true,
-			want:     string(goops.StatusMaintenance),
+			name:               "MaintenanceStatusIfLeader",
+			handler:            MaintenanceStatusIfLeader,
+			hookName:           "start",
+			leader:             true,
+			expectedStatusName: goopstest.StatusMaintenance,
 		},
 		{
-			name:     "MaintenanceStatusIfNotLeader",
-			handler:  MaintenanceStatusIfNotLeader,
-			hookName: "start",
-			leader:   false,
-			want:     string(goops.StatusMaintenance),
+			name:               "MaintenanceStatusIfNotLeader",
+			handler:            MaintenanceStatusIfNotLeader,
+			hookName:           "start",
+			leader:             false,
+			expectedStatusName: goopstest.StatusMaintenance,
 		},
 	}
 
@@ -88,8 +88,8 @@ func TestCharmLeader(t *testing.T) {
 				t.Fatalf("Run returned an error: %v", err)
 			}
 
-			if stateOut.UnitStatus != tc.want {
-				t.Errorf("got Status=%v, want %v", stateOut.UnitStatus, tc.want)
+			if stateOut.UnitStatus.Name != tc.expectedStatusName {
+				t.Errorf("got Status=%v, want %v", stateOut.UnitStatus, tc.expectedStatusName)
 			}
 
 			if stateOut.Leader != tc.leader {

--- a/goopstest/secret_test.go
+++ b/goopstest/secret_test.go
@@ -35,28 +35,28 @@ func GetSecretByLabel() error {
 
 func TestCharmGetSecretByLabel(t *testing.T) {
 	tests := []struct {
-		name     string
-		handler  func() error
-		hookName string
-		key      string
-		value    string
-		want     string
+		name               string
+		handler            func() error
+		hookName           string
+		key                string
+		value              string
+		expectedStatusName goopstest.StatusName
 	}{
 		{
-			name:     "GetSecretByLabel",
-			handler:  GetSecretByLabel,
-			hookName: "start",
-			key:      "secret-key",
-			value:    "expected-value",
-			want:     string(goops.StatusActive),
+			name:               "GetSecretByLabel",
+			handler:            GetSecretByLabel,
+			hookName:           "start",
+			key:                "secret-key",
+			value:              "expected-value",
+			expectedStatusName: goopstest.StatusActive,
 		},
 		{
-			name:     "GetSecretByLabelUnexpectedValue",
-			handler:  GetSecretByLabel,
-			hookName: "start",
-			key:      "secret-key",
-			value:    "unexpected-value",
-			want:     string(goops.StatusBlocked),
+			name:               "GetSecretByLabelUnexpectedValue",
+			handler:            GetSecretByLabel,
+			hookName:           "start",
+			key:                "secret-key",
+			value:              "unexpected-value",
+			expectedStatusName: goopstest.StatusBlocked,
 		},
 	}
 
@@ -85,8 +85,8 @@ func TestCharmGetSecretByLabel(t *testing.T) {
 				t.Fatalf("Run returned an error: %v", err)
 			}
 
-			if stateOut.UnitStatus != tc.want {
-				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.want)
+			if stateOut.UnitStatus.Name != tc.expectedStatusName {
+				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.expectedStatusName)
 			}
 
 			for _, secret := range stateOut.Secrets {
@@ -112,8 +112,8 @@ func TestCharmGetUnexistingSecretByLabel(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", err)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusMaintenance) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, string(goops.StatusMaintenance))
+	if stateOut.UnitStatus.Name != goopstest.StatusMaintenance {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusMaintenance)
 	}
 
 	if len(stateOut.Secrets) != 0 {
@@ -146,28 +146,28 @@ func GetSecretByID() error {
 
 func TestCharmGetSecretByID(t *testing.T) {
 	tests := []struct {
-		name     string
-		handler  func() error
-		hookName string
-		key      string
-		value    string
-		want     string
+		name               string
+		handler            func() error
+		hookName           string
+		key                string
+		value              string
+		expectedStatusName goopstest.StatusName
 	}{
 		{
-			name:     "GetSecretByID",
-			handler:  GetSecretByID,
-			hookName: "start",
-			key:      "secret-key",
-			value:    "expected-value",
-			want:     string(goops.StatusActive),
+			name:               "GetSecretByID",
+			handler:            GetSecretByID,
+			hookName:           "start",
+			key:                "secret-key",
+			value:              "expected-value",
+			expectedStatusName: goopstest.StatusActive,
 		},
 		{
-			name:     "GetSecretByIDUnexpectedValue",
-			handler:  GetSecretByID,
-			hookName: "start",
-			key:      "secret-key",
-			value:    "unexpected-value",
-			want:     string(goops.StatusBlocked),
+			name:               "GetSecretByIDUnexpectedValue",
+			handler:            GetSecretByID,
+			hookName:           "start",
+			key:                "secret-key",
+			value:              "unexpected-value",
+			expectedStatusName: goopstest.StatusBlocked,
 		},
 	}
 
@@ -200,8 +200,8 @@ func TestCharmGetSecretByID(t *testing.T) {
 				t.Fatalf("Run returned an error: %v", ctx.CharmErr)
 			}
 
-			if stateOut.UnitStatus != tc.want {
-				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.want)
+			if stateOut.UnitStatus.Name != tc.expectedStatusName {
+				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.expectedStatusName)
 			}
 
 			for _, secret := range stateOut.Secrets {
@@ -518,8 +518,8 @@ func TestCharmGetSecretInfoByID(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", ctx.CharmErr)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusActive) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, string(goops.StatusActive))
+	if stateOut.UnitStatus.Name != goopstest.StatusActive {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusActive)
 	}
 }
 
@@ -583,8 +583,8 @@ func TestCharmGetUnitSecretInfoByNonLeader(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", ctx.CharmErr)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusActive) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, string(goops.StatusActive))
+	if stateOut.UnitStatus.Name != goopstest.StatusActive {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusActive)
 	}
 }
 
@@ -628,8 +628,8 @@ func TestCharmGetSecretInfoByLabel(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", err)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusActive) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, string(goops.StatusActive))
+	if stateOut.UnitStatus.Name != goopstest.StatusActive {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusActive)
 	}
 }
 
@@ -693,8 +693,8 @@ func TestCharmGetUnitSecretInfoByLabelNonLeader(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", ctx.CharmErr)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusActive) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, string(goops.StatusActive))
+	if stateOut.UnitStatus.Name != goopstest.StatusActive {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusActive)
 	}
 }
 
@@ -747,8 +747,8 @@ func TestCharmGetSecretIDs(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", ctx.CharmErr)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusActive) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, string(goops.StatusActive))
+	if stateOut.UnitStatus.Name != goopstest.StatusActive {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusActive)
 	}
 
 	if len(stateOut.Secrets) != 2 {
@@ -836,8 +836,8 @@ func TestCharmGrantSecretToRelation(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", ctx.CharmErr)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusActive) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, string(goops.StatusActive))
+	if stateOut.UnitStatus.Name != goopstest.StatusActive {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusActive)
 	}
 }
 
@@ -883,8 +883,8 @@ func TestCharmGrantSecretToUnit(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", ctx.CharmErr)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusActive) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, string(goops.StatusActive))
+	if stateOut.UnitStatus.Name != goopstest.StatusActive {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusActive)
 	}
 }
 
@@ -966,8 +966,8 @@ func TestCharmSetSecret(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", ctx.CharmErr)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusActive) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, string(goops.StatusActive))
+	if stateOut.UnitStatus.Name != goopstest.StatusActive {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusActive)
 	}
 
 	if len(stateOut.Secrets) != 1 {
@@ -1080,8 +1080,8 @@ func TestCharmRevokeSecret(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", ctx.CharmErr)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusActive) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, string(goops.StatusActive))
+	if stateOut.UnitStatus.Name != goopstest.StatusActive {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusActive)
 	}
 
 	if len(stateOut.Secrets) != 1 {

--- a/goopstest/state.go
+++ b/goopstest/state.go
@@ -73,10 +73,26 @@ type Container struct {
 	CheckInfos      []client.CheckInfo
 }
 
+type StatusName string
+
+const (
+	StatusUnknown     StatusName = "unknown"
+	StatusError       StatusName = "error"
+	StatusActive      StatusName = "active"
+	StatusBlocked     StatusName = "blocked"
+	StatusMaintenance StatusName = "maintenance"
+	StatusWaiting     StatusName = "waiting"
+)
+
+type Status struct {
+	Name    StatusName
+	Message string
+}
+
 type State struct {
 	Leader             bool
-	UnitStatus         string
-	AppStatus          string
+	UnitStatus         Status
+	AppStatus          Status
 	Config             map[string]any
 	Secrets            []*Secret
 	ApplicationVersion string

--- a/goopstest/status_test.go
+++ b/goopstest/status_test.go
@@ -45,34 +45,35 @@ func UnitMaintenanceStatus() error {
 
 func TestCharmUnitStatus(t *testing.T) {
 	tests := []struct {
-		name     string
-		handler  func() error
-		hookName string
-		want     string
+		name                  string
+		handler               func() error
+		hookName              string
+		expectedStatusName    goopstest.StatusName
+		expectedStatusMessage string
 	}{
 		{
-			name:     "UnitActiveStatus",
-			handler:  UnitActiveStatus,
-			hookName: "start",
-			want:     string(goops.StatusActive),
+			name:               "UnitActiveStatus",
+			handler:            UnitActiveStatus,
+			hookName:           "start",
+			expectedStatusName: goopstest.StatusActive,
 		},
 		{
-			name:     "UnitBlockedStatus",
-			handler:  UnitBlockedStatus,
-			hookName: "start",
-			want:     string(goops.StatusBlocked),
+			name:               "UnitBlockedStatus",
+			handler:            UnitBlockedStatus,
+			hookName:           "start",
+			expectedStatusName: goopstest.StatusBlocked,
 		},
 		{
-			name:     "UnitWaitingStatus",
-			handler:  UnitWaitingStatus,
-			hookName: "start",
-			want:     string(goops.StatusWaiting),
+			name:               "UnitWaitingStatus",
+			handler:            UnitWaitingStatus,
+			hookName:           "start",
+			expectedStatusName: goopstest.StatusWaiting,
 		},
 		{
-			name:     "UnitMaintenanceStatus",
-			handler:  UnitMaintenanceStatus,
-			hookName: "start",
-			want:     string(goops.StatusMaintenance),
+			name:               "UnitMaintenanceStatus",
+			handler:            UnitMaintenanceStatus,
+			hookName:           "start",
+			expectedStatusName: goopstest.StatusMaintenance,
 		},
 	}
 
@@ -89,8 +90,8 @@ func TestCharmUnitStatus(t *testing.T) {
 				t.Fatalf("Run returned an error: %v", err)
 			}
 
-			if stateOut.UnitStatus != tc.want {
-				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.want)
+			if stateOut.UnitStatus.Name != tc.expectedStatusName {
+				t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, tc.expectedStatusName)
 			}
 		})
 	}
@@ -102,7 +103,9 @@ func TestCharmUnitStatusPreset(t *testing.T) {
 	}
 
 	stateIn := &goopstest.State{
-		UnitStatus: string(goops.StatusActive),
+		UnitStatus: goopstest.Status{
+			Name: goopstest.StatusActive,
+		},
 	}
 
 	stateOut, err := ctx.Run("start", stateIn)
@@ -110,8 +113,12 @@ func TestCharmUnitStatusPreset(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", err)
 	}
 
-	if stateOut.UnitStatus != string(goops.StatusMaintenance) {
-		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, string(goops.StatusMaintenance))
+	if stateOut.UnitStatus.Name != goopstest.StatusMaintenance {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusMaintenance)
+	}
+
+	if stateOut.UnitStatus.Message != "Performing maintenance" {
+		t.Errorf("got UnitStatus.Message=%q, want %q", stateOut.UnitStatus.Message, "Performing maintenance")
 	}
 }
 
@@ -153,34 +160,34 @@ func AppMaintenanceStatus() error {
 
 func TestCharmAppStatus(t *testing.T) {
 	tests := []struct {
-		name     string
-		handler  func() error
-		hookName string
-		want     string
+		name               string
+		handler            func() error
+		hookName           string
+		expectedStatusName goopstest.StatusName
 	}{
 		{
-			name:     "AppActiveStatus",
-			handler:  AppActiveStatus,
-			hookName: "start",
-			want:     string(goops.StatusActive),
+			name:               "AppActiveStatus",
+			handler:            AppActiveStatus,
+			hookName:           "start",
+			expectedStatusName: goopstest.StatusActive,
 		},
 		{
-			name:     "AppBlockedStatus",
-			handler:  AppBlockedStatus,
-			hookName: "start",
-			want:     string(goops.StatusBlocked),
+			name:               "AppBlockedStatus",
+			handler:            AppBlockedStatus,
+			hookName:           "start",
+			expectedStatusName: goopstest.StatusBlocked,
 		},
 		{
-			name:     "AppWaitingStatus",
-			handler:  AppWaitingStatus,
-			hookName: "start",
-			want:     string(goops.StatusWaiting),
+			name:               "AppWaitingStatus",
+			handler:            AppWaitingStatus,
+			hookName:           "start",
+			expectedStatusName: goopstest.StatusWaiting,
 		},
 		{
-			name:     "AppMaintenanceStatus",
-			handler:  AppMaintenanceStatus,
-			hookName: "start",
-			want:     string(goops.StatusMaintenance),
+			name:               "AppMaintenanceStatus",
+			handler:            AppMaintenanceStatus,
+			hookName:           "start",
+			expectedStatusName: goopstest.StatusMaintenance,
 		},
 	}
 
@@ -197,8 +204,8 @@ func TestCharmAppStatus(t *testing.T) {
 				t.Fatalf("Run returned an error: %v", err)
 			}
 
-			if stateOut.AppStatus != tc.want {
-				t.Errorf("got AppStatus=%q, want %q", stateOut.AppStatus, tc.want)
+			if stateOut.AppStatus.Name != tc.expectedStatusName {
+				t.Errorf("got AppStatus=%q, want %q", stateOut.AppStatus, tc.expectedStatusName)
 			}
 		})
 	}
@@ -210,7 +217,9 @@ func TestCharmAppStatusPreset(t *testing.T) {
 	}
 
 	stateIn := &goopstest.State{
-		AppStatus: string(goops.StatusActive),
+		AppStatus: goopstest.Status{
+			Name: goopstest.StatusActive,
+		},
 	}
 
 	stateOut, err := ctx.Run("start", stateIn)
@@ -218,7 +227,11 @@ func TestCharmAppStatusPreset(t *testing.T) {
 		t.Fatalf("Run returned an error: %v", err)
 	}
 
-	if stateOut.AppStatus != string(goops.StatusMaintenance) {
-		t.Errorf("got AppStatus=%q, want %q", stateOut.AppStatus, string(goops.StatusMaintenance))
+	if stateOut.AppStatus.Name != goopstest.StatusMaintenance {
+		t.Errorf("got AppStatus=%q, want %q", stateOut.AppStatus, goopstest.StatusMaintenance)
+	}
+
+	if stateOut.AppStatus.Message != "Performing maintenance" {
+		t.Errorf("got AppStatus.Message=%q, want %q", stateOut.AppStatus.Message, "Performing maintenance")
 	}
 }

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -330,7 +330,7 @@ func Configure() error {
 		return fmt.Errorf("could not get unit status: %w", err)
 	}
 
-	goops.LogInfof("Current unit status: %s %s", existingStatus.Code, existingStatus.Message)
+	goops.LogInfof("Current unit status: %s %s", existingStatus.Name, existingStatus.Message)
 
 	err = goops.SetUnitStatus(goops.StatusActive, "A happy charm")
 	if err != nil {

--- a/status.go
+++ b/status.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 )
 
-type StatusCode string
+type StatusName string
 
 const (
-	StatusActive      StatusCode = "active"
-	StatusBlocked     StatusCode = "blocked"
-	StatusWaiting     StatusCode = "waiting"
-	StatusMaintenance StatusCode = "maintenance"
+	StatusActive      StatusName = "active"
+	StatusBlocked     StatusName = "blocked"
+	StatusWaiting     StatusName = "waiting"
+	StatusMaintenance StatusName = "maintenance"
 )
 
 const (
@@ -20,11 +20,11 @@ const (
 )
 
 type Status struct {
-	Code    StatusCode `json:"status"`
+	Name    StatusName `json:"status"`
 	Message string     `json:"message"`
 }
 
-func SetUnitStatus(status StatusCode, message ...string) error {
+func SetUnitStatus(status StatusName, message ...string) error {
 	commandRunner := GetCommandRunner()
 
 	var args []string
@@ -43,7 +43,7 @@ func SetUnitStatus(status StatusCode, message ...string) error {
 	return nil
 }
 
-func SetAppStatus(status StatusCode, message ...string) error {
+func SetAppStatus(status StatusName, message ...string) error {
 	commandRunner := GetCommandRunner()
 
 	var args []string

--- a/status_test.go
+++ b/status_test.go
@@ -83,8 +83,8 @@ func TestGetUnitStatus_Success(t *testing.T) {
 		t.Fatalf("GetUnitStatus returned an error: %v", err)
 	}
 
-	if status.Code != goops.StatusActive {
-		t.Errorf("Expected status %q, got %q", goops.StatusActive, status.Code)
+	if status.Name != goops.StatusActive {
+		t.Errorf("Expected status %q, got %q", goops.StatusActive, status.Name)
 	}
 
 	if status.Message != "Unit is active" {
@@ -121,8 +121,8 @@ func TestGetAppStatus_Success(t *testing.T) {
 		t.Fatalf("GetAppStatus returned an error: %v", err)
 	}
 
-	if status.Code != goops.StatusActive {
-		t.Errorf("Expected status %q, got %q", goops.StatusActive, status.Code)
+	if status.Name != goops.StatusActive {
+		t.Errorf("Expected status %q, got %q", goops.StatusActive, status.Name)
 	}
 
 	if status.Message != "Application is active" {


### PR DESCRIPTION
# Description

We used to only capture the status name (ex. `active`, `blocked`, etc.) but not the message (ex `waiting for pebble`). We now capture both in a Status struct. 

Fixes #61 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
