### PR TITLE
feat: mimic juju behavior for relations [goopstest]

### DIFF
--- a/goopstest/command_runner.go
+++ b/goopstest/command_runner.go
@@ -367,6 +367,8 @@ func (f *fakeCommandRunner) handleRelationList(args []string) {
 			return
 		}
 	}
+
+	f.Err = fmt.Errorf("command relation-list failed: ERROR invalid value \"%s\" for option -r: relation not found", relationID)
 }
 
 func parseRelationSetArgs(args []string) (isApp bool, relationID string, data map[string]string, err error) {

--- a/goopstest/relation_test.go
+++ b/goopstest/relation_test.go
@@ -107,6 +107,36 @@ func TestCharmGetRelationIDsNoName(t *testing.T) {
 	}
 }
 
+func GetRelationIDsNoResult() error {
+	relationIDs, err := goops.GetRelationIDs("nonexistent")
+	if err != nil {
+		return err
+	}
+
+	if len(relationIDs) != 0 {
+		return fmt.Errorf("expected no relation IDs, got %d", len(relationIDs))
+	}
+
+	return nil
+}
+
+func TestCharmGetRelationIDsNoResult(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: GetRelationIDsNoResult,
+	}
+
+	stateIn := &goopstest.State{}
+
+	_, err := ctx.Run("start", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if ctx.CharmErr != nil {
+		t.Fatal("Expected no charm error, got one")
+	}
+}
+
 func ListRelationUnits1Result() error {
 	relationUnits, err := goops.ListRelationUnits("certificates:0")
 	if err != nil {
@@ -206,6 +236,30 @@ func TestCharmListRelationUnits(t *testing.T) {
 		if len(stateOut.Relations) != 1 {
 			t.Fatalf("expected 1 relation, got %d", len(stateOut.Relations))
 		}
+	}
+}
+
+func TestListRelationUnitsResultNotFound(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: ListRelationUnits1Result,
+	}
+
+	stateIn := &goopstest.State{
+		Relations: []*goopstest.Relation{},
+	}
+
+	_, err := ctx.Run("start", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if ctx.CharmErr == nil {
+		t.Fatal("Expected CharmErr to be set, got nil")
+	}
+
+	expectedErr := "failed to list relation data: command relation-list failed: ERROR invalid value \"certificates:0\" for option -r: relation not found"
+	if ctx.CharmErr.Error() != expectedErr {
+		t.Errorf("got CharmErr=%q, want %q", ctx.CharmErr.Error(), expectedErr)
 	}
 }
 

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -305,7 +305,7 @@ func Configure() error {
 	}
 
 	if len(certificatesRelationID) > 0 {
-		uuid, err := goops.GetRelationModel(certificatesRelationID[0])
+		uuid, err := goops.GetRelationModelUUID(certificatesRelationID[0])
 		if err != nil {
 			return fmt.Errorf("could not get relation model: %w", err)
 		}

--- a/relations.go
+++ b/relations.go
@@ -13,6 +13,14 @@ const (
 	relationModelGetCommand = "relation-model-get"
 )
 
+// GetRelationIDs retrieves the IDs of all relations for a given endpoint.
+// The output is useful as input to:
+// - ListRelationUnits
+// - GetAppRelationData
+// - GetUnitRelationData
+// - SetUnitRelationData
+// - SetAppRelationData
+// - GetRelationModel
 func GetRelationIDs(name string) ([]string, error) {
 	commandRunner := GetCommandRunner()
 
@@ -33,6 +41,10 @@ func GetRelationIDs(name string) ([]string, error) {
 	return relationIDs, nil
 }
 
+// GetUnitRelationData retrieves the relation data for a specific unit in a relation by its ID.
+// unitID can either be:
+// - The remote unit ID which can be retrieved via goops.ListRelationUnits()
+// - The local unit ID which you can retrieve via goops.ReadEnv()
 func GetUnitRelationData(id string, unitID string) (map[string]string, error) {
 	commandRunner := GetCommandRunner()
 
@@ -55,6 +67,10 @@ func GetUnitRelationData(id string, unitID string) (map[string]string, error) {
 	return relationContent, nil
 }
 
+// GetUnitRelationData retrieves the relation data for a specific app in a relation by its ID.
+// unitID can either be:
+// - The remote unit ID which can be retrieved via goops.ListRelationUnits()
+// - The local unit ID which you can retrieve via goops.ReadEnv()
 func GetAppRelationData(id string, unitID string) (map[string]string, error) {
 	commandRunner := GetCommandRunner()
 
@@ -77,7 +93,7 @@ func GetAppRelationData(id string, unitID string) (map[string]string, error) {
 	return relationContent, nil
 }
 
-// ListRelationUnits lists all units in a relation by its ID.
+// ListRelationUnits lists all remote units in a relation by its ID.
 func ListRelationUnits(id string) ([]string, error) {
 	commandRunner := GetCommandRunner()
 
@@ -98,6 +114,7 @@ func ListRelationUnits(id string) ([]string, error) {
 	return relationList, nil
 }
 
+// GetRelationApp retrieves the remote application name for a relation by its ID.
 func GetRelationApp(id string) (string, error) {
 	commandRunner := GetCommandRunner()
 
@@ -118,6 +135,7 @@ func GetRelationApp(id string) (string, error) {
 	return relationApp, nil
 }
 
+// SetUnitRelationData sets the local unit relation data in a relation by its ID.
 func SetUnitRelationData(id string, data map[string]string) error {
 	commandRunner := GetCommandRunner()
 
@@ -139,6 +157,7 @@ func SetUnitRelationData(id string, data map[string]string) error {
 	return nil
 }
 
+// SetAppRelationData sets the local application relation data in a relation by its ID.
 func SetAppRelationData(id string, data map[string]string) error {
 	commandRunner := GetCommandRunner()
 
@@ -166,7 +185,8 @@ type RelationModel struct {
 	UUID string `json:"uuid"`
 }
 
-func GetRelationModel(id string) (string, error) {
+// GetRelationModel retrieves the relation model UUID for a relation by its ID.
+func GetRelationModelUUID(id string) (string, error) {
 	commandRunner := GetCommandRunner()
 
 	args := []string{"-r=" + id, "--format=json"}

--- a/relations_test.go
+++ b/relations_test.go
@@ -219,7 +219,7 @@ func TestRelationModelGet_Success(t *testing.T) {
 
 	goops.SetCommandRunner(fakeRunner)
 
-	uuid, err := goops.GetRelationModel("certificates:0")
+	uuid, err := goops.GetRelationModelUUID("certificates:0")
 	if err != nil {
 		t.Fatalf("RelationModelGet returned an error: %v", err)
 	}


### PR DESCRIPTION
# Description

- [ ] Compare real juju behavior in happy and non-happy paths for relation hook commands:
  - [x] relation-ids
  - [x] relation-list
  - [ ] relation-get
  - [ ] relation-set
  - [ ] relation-model-get
- [x] Add API documentation 
- [ ] Validate against peer relations

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
