### PR TITLE
feat: mimic juju behavior for ports and status [goopstest]

### DIFF
--- a/goal_state.go
+++ b/goal_state.go
@@ -6,19 +6,16 @@ const (
 	goalStateCommand = "goal-state"
 )
 
-type UnitStatus struct {
+type GoalStateStatusContents struct {
 	Status string `json:"status"`
-	Since  string `json:"since"`
+	Since  string `json:"since,omitempty"`
 }
 
-type RelationStatus struct {
-	Status string `json:"status"`
-	Since  string `json:"since"`
-}
+type UnitsGoalStateContents map[string]GoalStateStatusContents
 
 type GoalState struct {
-	Units     map[string]*UnitStatus                `json:"units"`
-	Relations map[string]map[string]*RelationStatus `json:"relations"`
+	Units     UnitsGoalStateContents            `json:"units"`
+	Relations map[string]UnitsGoalStateContents `json:"relations"`
 }
 
 func GetGoalState() (*GoalState, error) {

--- a/goal_state_test.go
+++ b/goal_state_test.go
@@ -15,13 +15,13 @@ func TestGoalState_Success(t *testing.T) {
 	goops.SetCommandRunner(fakeRunner)
 
 	expectedGoalState := goops.GoalState{
-		Units: map[string]*goops.UnitStatus{
+		Units: goops.UnitsGoalStateContents{
 			"example/0": {
 				Status: "active",
 				Since:  "2025-04-03 20:05:33Z",
 			},
 		},
-		Relations: map[string]map[string]*goops.RelationStatus{
+		Relations: map[string]goops.UnitsGoalStateContents{
 			"certificates": {
 				"tls-certificates-requirer": {
 					Status: "joined",

--- a/goopstest/README.md
+++ b/goopstest/README.md
@@ -52,13 +52,8 @@ func TestCharm(t *testing.T) {
 	}
 
 	// Assert
-	expectedStatus := goopstest.Status{
-		Name:    goopstest.StatusBlocked,
-		Message: "Unit is not a leader",
-	}
-
-	if stateOut.UnitStatus != expectedStatus {
-		t.Errorf("got Status=%q, want %q", stateOut.UnitStatus, expectedStatus)
+	if stateOut.UnitStatus.Name != goopstest.StatusBlocked {
+		t.Errorf("Expected unit status to be %s, got %s", goopstest.StatusBlocked, stateOut.UnitStatus.Name)
 	}
 }
 ```

--- a/goopstest/command_runner.go
+++ b/goopstest/command_runner.go
@@ -168,6 +168,12 @@ func (f *fakeCommandRunner) handleOpenPort(args []string) {
 		return
 	}
 
+	for _, p := range f.Ports {
+		if p.Port == port && p.Protocol == protocol {
+			return
+		}
+	}
+
 	f.Ports = append(f.Ports, &Port{
 		Port:     port,
 		Protocol: protocol,
@@ -201,8 +207,6 @@ func (f *fakeCommandRunner) handleClosePort(args []string) {
 			return
 		}
 	}
-
-	f.Err = fmt.Errorf("port %d/%s not found", port, protocol)
 }
 
 func (f *fakeCommandRunner) handleConfigGet(_ []string) {

--- a/goopstest/context.go
+++ b/goopstest/context.go
@@ -48,6 +48,12 @@ func (c *Context) Run(hookName string, state *State) (*State, error) {
 		}
 	}
 
+	if state.UnitStatus == nil {
+		state.UnitStatus = &Status{
+			Name: StatusUnknown,
+		}
+	}
+
 	fakeCommand := &fakeCommandRunner{
 		Output:        []byte(``),
 		Err:           nil,
@@ -61,6 +67,8 @@ func (c *Context) Run(hookName string, state *State) (*State, error) {
 		AppName:       c.AppName,
 		UnitID:        c.UnitID,
 		Model:         state.Model,
+		UnitStatus:    state.UnitStatus,
+		AppStatus:     state.AppStatus,
 	}
 
 	fakeEnv := &fakeEnvGetter{
@@ -113,6 +121,8 @@ func (c *Context) RunAction(actionName string, state *State, params map[string]a
 		AppName:          c.AppName,
 		UnitID:           c.UnitID,
 		Model:            state.Model,
+		UnitStatus:       state.UnitStatus,
+		AppStatus:        state.AppStatus,
 	}
 
 	if state.Model == nil {

--- a/goopstest/docs_test.go
+++ b/goopstest/docs_test.go
@@ -47,13 +47,8 @@ func TestCharmBasic(t *testing.T) {
 	}
 
 	// Assert
-	expectedStatus := goopstest.Status{
-		Name:    goopstest.StatusBlocked,
-		Message: "Unit is not a leader",
-	}
-
-	if stateOut.UnitStatus != expectedStatus {
-		t.Errorf("got Status=%q, want %q", stateOut.UnitStatus, expectedStatus)
+	if stateOut.UnitStatus.Name != goopstest.StatusBlocked {
+		t.Errorf("Expected unit status to be %s, got %s", goopstest.StatusBlocked, stateOut.UnitStatus.Name)
 	}
 }
 

--- a/goopstest/ports_test.go
+++ b/goopstest/ports_test.go
@@ -109,3 +109,93 @@ func TestSetPortsDifferentSet(t *testing.T) {
 		t.Errorf("Expected protocol 'tcp', got '%s'", stateOut.Ports[0].Protocol)
 	}
 }
+
+func ClosePort() error {
+	err := goops.ClosePort(80, "udp")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestCloseUnOpenedPort(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: ClosePort,
+	}
+
+	stateIn := &goopstest.State{
+		Ports: []*goopstest.Port{
+			{
+				Port:     81,
+				Protocol: "udp",
+			},
+		},
+	}
+
+	stateOut, err := ctx.Run("start", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if ctx.CharmErr != nil {
+		t.Errorf("Expected no error, got %v", ctx.CharmErr)
+	}
+
+	if len(stateOut.Ports) != 1 {
+		t.Fatalf("Expected 1 port, got %d", len(stateOut.Ports))
+	}
+
+	if stateOut.Ports[0].Port != 81 {
+		t.Errorf("Expected port 81, got %d", stateOut.Ports[0].Port)
+	}
+
+	if stateOut.Ports[0].Protocol != "udp" {
+		t.Errorf("Expected protocol 'udp', got '%s'", stateOut.Ports[0].Protocol)
+	}
+}
+
+func OpenPort() error {
+	err := goops.OpenPort(81, "udp")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestOpenOpenedPort(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: OpenPort,
+	}
+
+	stateIn := &goopstest.State{
+		Ports: []*goopstest.Port{
+			{
+				Port:     81,
+				Protocol: "udp",
+			},
+		},
+	}
+
+	stateOut, err := ctx.Run("start", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if ctx.CharmErr != nil {
+		t.Errorf("Expected no error, got %v", ctx.CharmErr)
+	}
+
+	if len(stateOut.Ports) != 1 {
+		t.Fatalf("Expected 1 port, got %d", len(stateOut.Ports))
+	}
+
+	if stateOut.Ports[0].Port != 81 {
+		t.Errorf("Expected port 81, got %d", stateOut.Ports[0].Port)
+	}
+
+	if stateOut.Ports[0].Protocol != "udp" {
+		t.Errorf("Expected protocol 'udp', got '%s'", stateOut.Ports[0].Protocol)
+	}
+}

--- a/goopstest/state.go
+++ b/goopstest/state.go
@@ -95,14 +95,14 @@ const (
 )
 
 type Status struct {
-	Name    StatusName
-	Message string
+	Name    StatusName `json:"status"`
+	Message string     `json:"message"`
 }
 
 type State struct {
 	Leader             bool
-	UnitStatus         Status
-	AppStatus          Status
+	UnitStatus         *Status
+	AppStatus          *Status
 	Config             map[string]any
 	Secrets            []*Secret
 	ApplicationVersion string

--- a/goopstest/status_test.go
+++ b/goopstest/status_test.go
@@ -1,13 +1,14 @@
 package goopstest_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gruyaume/goops"
 	"github.com/gruyaume/goops/goopstest"
 )
 
-func UnitActiveStatus() error {
+func SetUnitStatusActive() error {
 	err := goops.SetUnitStatus(goops.StatusActive, "Charm is active")
 	if err != nil {
 		return err
@@ -16,7 +17,7 @@ func UnitActiveStatus() error {
 	return nil
 }
 
-func UnitBlockedStatus() error {
+func SetUnitStatusBlocked() error {
 	err := goops.SetUnitStatus(goops.StatusBlocked, "This is a test message")
 	if err != nil {
 		return err
@@ -25,7 +26,7 @@ func UnitBlockedStatus() error {
 	return nil
 }
 
-func UnitWaitingStatus() error {
+func SetUnitStatusWaiting() error {
 	err := goops.SetUnitStatus(goops.StatusWaiting, "Waiting for something")
 	if err != nil {
 		return err
@@ -34,7 +35,7 @@ func UnitWaitingStatus() error {
 	return nil
 }
 
-func UnitMaintenanceStatus() error {
+func SetUnitStatusMaintenance() error {
 	err := goops.SetUnitStatus(goops.StatusMaintenance, "Performing maintenance")
 	if err != nil {
 		return err
@@ -43,7 +44,7 @@ func UnitMaintenanceStatus() error {
 	return nil
 }
 
-func TestCharmUnitStatus(t *testing.T) {
+func TestCharmSetUnitStatus(t *testing.T) {
 	tests := []struct {
 		name                  string
 		handler               func() error
@@ -52,26 +53,26 @@ func TestCharmUnitStatus(t *testing.T) {
 		expectedStatusMessage string
 	}{
 		{
-			name:               "UnitActiveStatus",
-			handler:            UnitActiveStatus,
+			name:               "SetUnitStatusActive",
+			handler:            SetUnitStatusActive,
 			hookName:           "start",
 			expectedStatusName: goopstest.StatusActive,
 		},
 		{
-			name:               "UnitBlockedStatus",
-			handler:            UnitBlockedStatus,
+			name:               "SetUnitStatusBlocked",
+			handler:            SetUnitStatusBlocked,
 			hookName:           "start",
 			expectedStatusName: goopstest.StatusBlocked,
 		},
 		{
-			name:               "UnitWaitingStatus",
-			handler:            UnitWaitingStatus,
+			name:               "SetUnitStatusWaiting",
+			handler:            SetUnitStatusWaiting,
 			hookName:           "start",
 			expectedStatusName: goopstest.StatusWaiting,
 		},
 		{
-			name:               "UnitMaintenanceStatus",
-			handler:            UnitMaintenanceStatus,
+			name:               "SetUnitStatusMaintenance",
+			handler:            SetUnitStatusMaintenance,
 			hookName:           "start",
 			expectedStatusName: goopstest.StatusMaintenance,
 		},
@@ -97,13 +98,13 @@ func TestCharmUnitStatus(t *testing.T) {
 	}
 }
 
-func TestCharmUnitStatusPreset(t *testing.T) {
+func TestCharmSetUnitStatusPreset(t *testing.T) {
 	ctx := goopstest.Context{
-		Charm: UnitMaintenanceStatus,
+		Charm: SetUnitStatusMaintenance,
 	}
 
 	stateIn := &goopstest.State{
-		UnitStatus: goopstest.Status{
+		UnitStatus: &goopstest.Status{
 			Name: goopstest.StatusActive,
 		},
 	}
@@ -122,7 +123,7 @@ func TestCharmUnitStatusPreset(t *testing.T) {
 	}
 }
 
-func AppActiveStatus() error {
+func SetAppStatusActive() error {
 	err := goops.SetAppStatus(goops.StatusActive, "Charm is active")
 	if err != nil {
 		return err
@@ -131,7 +132,7 @@ func AppActiveStatus() error {
 	return nil
 }
 
-func AppBlockedStatus() error {
+func SetAppStatusBlocked() error {
 	err := goops.SetAppStatus(goops.StatusBlocked, "This is a test message")
 	if err != nil {
 		return err
@@ -140,7 +141,7 @@ func AppBlockedStatus() error {
 	return nil
 }
 
-func AppWaitingStatus() error {
+func SetAppStatusWaiting() error {
 	err := goops.SetAppStatus(goops.StatusWaiting, "Waiting for something")
 	if err != nil {
 		return err
@@ -149,7 +150,7 @@ func AppWaitingStatus() error {
 	return nil
 }
 
-func AppMaintenanceStatus() error {
+func SetAppStatusMaintenance() error {
 	err := goops.SetAppStatus(goops.StatusMaintenance, "Performing maintenance")
 	if err != nil {
 		return err
@@ -158,7 +159,7 @@ func AppMaintenanceStatus() error {
 	return nil
 }
 
-func TestCharmAppStatus(t *testing.T) {
+func TestCharmSetAppStatus(t *testing.T) {
 	tests := []struct {
 		name               string
 		handler            func() error
@@ -166,26 +167,26 @@ func TestCharmAppStatus(t *testing.T) {
 		expectedStatusName goopstest.StatusName
 	}{
 		{
-			name:               "AppActiveStatus",
-			handler:            AppActiveStatus,
+			name:               "SetAppStatusActive",
+			handler:            SetAppStatusActive,
 			hookName:           "start",
 			expectedStatusName: goopstest.StatusActive,
 		},
 		{
-			name:               "AppBlockedStatus",
-			handler:            AppBlockedStatus,
+			name:               "SetAppStatusBlocked",
+			handler:            SetAppStatusBlocked,
 			hookName:           "start",
 			expectedStatusName: goopstest.StatusBlocked,
 		},
 		{
-			name:               "AppWaitingStatus",
-			handler:            AppWaitingStatus,
+			name:               "SetAppStatusWaiting",
+			handler:            SetAppStatusWaiting,
 			hookName:           "start",
 			expectedStatusName: goopstest.StatusWaiting,
 		},
 		{
-			name:               "AppMaintenanceStatus",
-			handler:            AppMaintenanceStatus,
+			name:               "SetAppStatusMaintenance",
+			handler:            SetAppStatusMaintenance,
 			hookName:           "start",
 			expectedStatusName: goopstest.StatusMaintenance,
 		},
@@ -213,11 +214,11 @@ func TestCharmAppStatus(t *testing.T) {
 
 func TestCharmAppStatusPreset(t *testing.T) {
 	ctx := goopstest.Context{
-		Charm: AppMaintenanceStatus,
+		Charm: SetAppStatusMaintenance,
 	}
 
 	stateIn := &goopstest.State{
-		AppStatus: goopstest.Status{
+		AppStatus: &goopstest.Status{
 			Name: goopstest.StatusActive,
 		},
 	}
@@ -233,5 +234,174 @@ func TestCharmAppStatusPreset(t *testing.T) {
 
 	if stateOut.AppStatus.Message != "Performing maintenance" {
 		t.Errorf("got AppStatus.Message=%q, want %q", stateOut.AppStatus.Message, "Performing maintenance")
+	}
+}
+
+func GetUnitStatus() error {
+	status, err := goops.GetUnitStatus()
+	if err != nil {
+		return err
+	}
+
+	if status.Name != goops.StatusActive {
+		return fmt.Errorf("expected active status, got %q", status.Name)
+	}
+
+	if status.Message != "My expected message" {
+		return fmt.Errorf("unexpected message: got %q, want %q", status.Message, "My expected message")
+	}
+
+	return nil
+}
+
+func TestGetUnitStatus(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: GetUnitStatus,
+	}
+
+	stateIn := &goopstest.State{
+		UnitStatus: &goopstest.Status{
+			Name:    goopstest.StatusActive,
+			Message: "My expected message",
+		},
+	}
+
+	stateOut, err := ctx.Run("install", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if ctx.CharmErr != nil {
+		t.Fatalf("expected no error, got %v", ctx.CharmErr)
+	}
+
+	if stateOut.UnitStatus.Name != goopstest.StatusActive {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusActive)
+	}
+
+	if stateOut.UnitStatus.Message != "My expected message" {
+		t.Errorf("got UnitStatus.Message=%q, want %q", stateOut.UnitStatus.Message, "My expected message")
+	}
+}
+
+func GetUnitStatusUnknown() error {
+	status, err := goops.GetUnitStatus()
+	if err != nil {
+		return err
+	}
+
+	if status.Name != goops.StatusUnknown {
+		return fmt.Errorf("expected unknown status, got %q", status.Name)
+	}
+
+	return nil
+}
+
+func TestGetUnitStatusNotSet(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: GetUnitStatusUnknown,
+	}
+
+	stateIn := &goopstest.State{}
+
+	stateOut, err := ctx.Run("install", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if ctx.CharmErr != nil {
+		t.Fatalf("expected no error, got %v", ctx.CharmErr)
+	}
+
+	if stateOut.UnitStatus.Name != goopstest.StatusUnknown {
+		t.Errorf("got UnitStatus=%q, want %q", stateOut.UnitStatus, goopstest.StatusUnknown)
+	}
+
+	if stateOut.UnitStatus.Message != "" {
+		t.Errorf("got UnitStatus.Message=%q, want empty string", stateOut.UnitStatus.Message)
+	}
+}
+
+func GetAppStatus() error {
+	status, err := goops.GetAppStatus()
+	if err != nil {
+		return err
+	}
+
+	if status.Name != goops.StatusActive {
+		return fmt.Errorf("expected active status, got %q", status.Name)
+	}
+
+	if status.Message != "My expected message" {
+		return fmt.Errorf("unexpected message: got %q, want %q", status.Message, "My expected message")
+	}
+
+	return nil
+}
+
+func TestGetAppStatusLeader(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: GetAppStatus,
+	}
+
+	stateIn := &goopstest.State{
+		Leader: true,
+		AppStatus: &goopstest.Status{
+			Name:    goopstest.StatusActive,
+			Message: "My expected message",
+		},
+	}
+
+	stateOut, err := ctx.Run("install", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if ctx.CharmErr != nil {
+		t.Fatalf("expected no error, got %v", ctx.CharmErr)
+	}
+
+	if stateOut.AppStatus.Name != goopstest.StatusActive {
+		t.Errorf("got AppStatus=%q, want %q", stateOut.AppStatus, goopstest.StatusActive)
+	}
+
+	if stateOut.AppStatus.Message != "My expected message" {
+		t.Errorf("got AppStatus.Message=%q, want %q", stateOut.AppStatus.Message, "My expected message")
+	}
+}
+
+func TestGetAppStatusNonLeader(t *testing.T) {
+	ctx := goopstest.Context{
+		Charm: GetAppStatus,
+	}
+
+	stateIn := &goopstest.State{
+		Leader: false,
+		AppStatus: &goopstest.Status{
+			Name:    goopstest.StatusActive,
+			Message: "My expected message",
+		},
+	}
+
+	stateOut, err := ctx.Run("install", stateIn)
+	if err != nil {
+		t.Fatalf("Run returned an error: %v", err)
+	}
+
+	if ctx.CharmErr == nil {
+		t.Fatalf("expected CharmErr to be set, got nil")
+	}
+
+	expectedErr := "failed to get application status: command status-get failed: ERROR finding application status: this unit is not the leader"
+	if ctx.CharmErr.Error() != expectedErr {
+		t.Errorf("got CharmErr=%q, want %q", ctx.CharmErr.Error(), expectedErr)
+	}
+
+	if stateOut.AppStatus.Name != goopstest.StatusActive {
+		t.Errorf("got AppStatus=%q, want %q", stateOut.AppStatus, goopstest.StatusActive)
+	}
+
+	if stateOut.AppStatus.Message != "My expected message" {
+		t.Errorf("got AppStatus.Message=%q, want %q", stateOut.AppStatus.Message, "My expected message")
 	}
 }

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -262,12 +262,10 @@ func Configure() error {
 
 	privateAddress, err := goops.GetUnitPrivateAddress()
 	if err != nil {
-		_ = goops.SetUnitStatus(goops.StatusWaiting, "Waiting for unit private address")
 		return nil
 	}
 
 	if privateAddress == "" {
-		_ = goops.SetUnitStatus(goops.StatusWaiting, "Waiting for unit private address")
 		return nil
 	}
 
@@ -337,7 +335,6 @@ func Configure() error {
 
 	peerRelation, err := goops.GetRelationIDs(PeerRelationName)
 	if err != nil {
-		_ = goops.SetUnitStatus(goops.StatusWaiting, "Waiting for peer relation")
 		return nil
 	}
 
@@ -352,11 +349,6 @@ func Configure() error {
 	}
 
 	goops.LogInfof("Current unit status: %s %s", existingStatus.Name, existingStatus.Message)
-
-	err = goops.SetUnitStatus(goops.StatusActive, "A happy charm")
-	if err != nil {
-		return fmt.Errorf("could not set unit status: %w", err)
-	}
 
 	goops.LogInfof("Status set to active")
 

--- a/internal/charm/hooks.go
+++ b/internal/charm/hooks.go
@@ -229,8 +229,43 @@ func validateGoalState() error {
 		return fmt.Errorf("goal state units is nil")
 	}
 
-	if goalState.Units["example/0"] == nil {
+	expected := goops.GoalStateStatusContents{}
+	if goalState.Units["example/0"] == expected {
 		return fmt.Errorf("goal state unit is nil")
+	}
+
+	return nil
+}
+
+func validateAppStatus() error {
+	isLeader, err := goops.IsLeader()
+	if err != nil {
+		return fmt.Errorf("could not check if unit is leader: %w", err)
+	}
+
+	if !isLeader {
+		goops.LogInfof("This unit is not the leader, skipping application status update")
+		return nil
+	}
+
+	goops.LogInfof("This unit is the leader, setting application status")
+
+	existingAppStatus, err := goops.GetAppStatus()
+	if err != nil {
+		return fmt.Errorf("could not get application status: %w", err)
+	}
+
+	goops.LogInfof("Current application status: %s %s", existingAppStatus.Name, existingAppStatus.Message)
+
+	if existingAppStatus.Name != goops.StatusActive {
+		err = goops.SetAppStatus(goops.StatusActive, "Application is active")
+		if err != nil {
+			return fmt.Errorf("could not set application status: %w", err)
+		}
+
+		goops.LogInfof("Application status set to active")
+	} else {
+		goops.LogInfof("Application status is already active, no need to set it")
 	}
 
 	return nil
@@ -333,24 +368,17 @@ func Configure() error {
 		return fmt.Errorf("could not set application version using goops: %w", err)
 	}
 
-	peerRelation, err := goops.GetRelationIDs(PeerRelationName)
-	if err != nil {
-		return nil
-	}
-
-	if len(peerRelation) == 0 {
-		goops.LogDebugf("No peer relation found, waiting for it to be created")
-		return nil
-	}
-
-	existingStatus, err := goops.GetUnitStatus()
+	existingUnitStatus, err := goops.GetUnitStatus()
 	if err != nil {
 		return fmt.Errorf("could not get unit status: %w", err)
 	}
 
-	goops.LogInfof("Current unit status: %s %s", existingStatus.Name, existingStatus.Message)
+	err = validateAppStatus()
+	if err != nil {
+		return fmt.Errorf("could not validate application status: %w", err)
+	}
 
-	goops.LogInfof("Status set to active")
+	goops.LogInfof("Current unit status: %s %s", existingUnitStatus.Name, existingUnitStatus.Message)
 
 	return nil
 }

--- a/ports_test.go
+++ b/ports_test.go
@@ -58,6 +58,32 @@ func TestOpenPortUDP_Success(t *testing.T) {
 	}
 }
 
+func TestOpenPortICMP_Success(t *testing.T) {
+	fakeRunner := &FakeRunner{
+		Output: []byte(``),
+		Err:    nil,
+	}
+
+	goops.SetCommandRunner(fakeRunner)
+
+	err := goops.OpenPort(0, "icmp")
+	if err != nil {
+		t.Fatalf("OpenPort returned an error: %v", err)
+	}
+
+	if fakeRunner.Command != "open-port" {
+		t.Errorf("Expected command %q, got %q", "open-port", fakeRunner.Command)
+	}
+
+	if len(fakeRunner.Args) != 1 {
+		t.Fatalf("Expected 1 argument, got %d", len(fakeRunner.Args))
+	}
+
+	if fakeRunner.Args[0] != "icmp" {
+		t.Errorf("Expected argument %q, got %q", "icmp", fakeRunner.Args[0])
+	}
+}
+
 func TestOpenPortInvalidPort_Failure(t *testing.T) {
 	fakeRunner := &FakeRunner{
 		Output: []byte(``),

--- a/status.go
+++ b/status.go
@@ -88,8 +88,9 @@ func GetUnitStatus() (*UnitStatus, error) {
 }
 
 type AppStatus struct {
-	Name    StatusName `json:"status"`
-	Message string     `json:"message"`
+	Name    StatusName            `json:"status"`
+	Message string                `json:"message"`
+	Units   map[string]UnitStatus `json:"units"`
 }
 
 type appStatusReturn struct {

--- a/status.go
+++ b/status.go
@@ -25,6 +25,7 @@ type Status struct {
 	Message string     `json:"message"`
 }
 
+// SetUnitStatus sets the unit status.
 func SetUnitStatus(status StatusName, message ...string) error {
 	commandRunner := GetCommandRunner()
 
@@ -44,6 +45,8 @@ func SetUnitStatus(status StatusName, message ...string) error {
 	return nil
 }
 
+// SetAppStatus sets the application status.
+// Only the leader unit can set the application status.
 func SetAppStatus(status StatusName, message ...string) error {
 	commandRunner := GetCommandRunner()
 
@@ -63,6 +66,7 @@ func SetAppStatus(status StatusName, message ...string) error {
 	return nil
 }
 
+// GetUnitStatus returns the unit status information.
 func GetUnitStatus() (*Status, error) {
 	commandRunner := GetCommandRunner()
 
@@ -83,6 +87,8 @@ func GetUnitStatus() (*Status, error) {
 	return &status, nil
 }
 
+// GetAppStatus returns the application status information.
+// Only the leader unit can retrieve the application status.
 func GetAppStatus() (*Status, error) {
 	commandRunner := GetCommandRunner()
 

--- a/status.go
+++ b/status.go
@@ -12,6 +12,7 @@ const (
 	StatusBlocked     StatusName = "blocked"
 	StatusWaiting     StatusName = "waiting"
 	StatusMaintenance StatusName = "maintenance"
+	StatusUnknown     StatusName = "unknown"
 )
 
 const (

--- a/status.go
+++ b/status.go
@@ -20,7 +20,7 @@ const (
 	statusSetCommand = "status-set"
 )
 
-type Status struct {
+type UnitStatus struct {
 	Name    StatusName `json:"status"`
 	Message string     `json:"message"`
 }
@@ -67,7 +67,7 @@ func SetAppStatus(status StatusName, message ...string) error {
 }
 
 // GetUnitStatus returns the unit status information.
-func GetUnitStatus() (*Status, error) {
+func GetUnitStatus() (*UnitStatus, error) {
 	commandRunner := GetCommandRunner()
 
 	args := []string{"--include-data", "--format=json"}
@@ -77,7 +77,7 @@ func GetUnitStatus() (*Status, error) {
 		return nil, fmt.Errorf("failed to get status: %w", err)
 	}
 
-	var status Status
+	var status UnitStatus
 
 	err = json.Unmarshal(output, &status)
 	if err != nil {
@@ -87,9 +87,18 @@ func GetUnitStatus() (*Status, error) {
 	return &status, nil
 }
 
+type AppStatus struct {
+	Name    StatusName `json:"status"`
+	Message string     `json:"message"`
+}
+
+type appStatusReturn struct {
+	AppStatus AppStatus `json:"application-status"`
+}
+
 // GetAppStatus returns the application status information.
 // Only the leader unit can retrieve the application status.
-func GetAppStatus() (*Status, error) {
+func GetAppStatus() (*AppStatus, error) {
 	commandRunner := GetCommandRunner()
 
 	args := []string{"--application", "--include-data", "--format=json"}
@@ -99,12 +108,12 @@ func GetAppStatus() (*Status, error) {
 		return nil, fmt.Errorf("failed to get application status: %w", err)
 	}
 
-	var status Status
+	var status appStatusReturn
 
 	err = json.Unmarshal(output, &status)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse application status: %w", err)
 	}
 
-	return &status, nil
+	return &status.AppStatus, nil
 }

--- a/status_test.go
+++ b/status_test.go
@@ -110,7 +110,7 @@ func TestGetUnitStatus_Success(t *testing.T) {
 
 func TestGetAppStatus_Success(t *testing.T) {
 	fakeRunner := &FakeRunner{
-		Output: []byte(`{"status": "active", "message": "Application is active"}`),
+		Output: []byte(`{"application-status":{"message":"Application is active","status":"active","status-data":{},"units":{"example/0":{"message":"","status":"unknown","status-data":{}},"example/1":{"message":"Application is active","status":"active","status-data":{}}}}}`),
 		Err:    nil,
 	}
 

--- a/status_test.go
+++ b/status_test.go
@@ -129,6 +129,14 @@ func TestGetAppStatus_Success(t *testing.T) {
 		t.Errorf("Expected message %q, got %q", "Application is active", status.Message)
 	}
 
+	if status.Units["example/0"].Name != goops.StatusUnknown {
+		t.Errorf("Expected unit status %q, got %q", goops.StatusUnknown, status.Units["example/0"].Name)
+	}
+
+	if status.Units["example/1"].Name != goops.StatusActive {
+		t.Errorf("Expected unit status %q, got %q", goops.StatusActive, status.Units["example/1"].Name)
+	}
+
 	if fakeRunner.Command != "status-get" {
 		t.Errorf("Expected command %q, got %q", "status-get", fakeRunner.Command)
 	}


### PR DESCRIPTION
# Description

- Mimic juju behavior for ports and status in goopstest
- Add missing handler for `status-get` in goopstest
- Add missing `unknown` status in possible status returned by `GetStatus`
- Fix issue where goops unmarshalled application status incorrectly. The expected json struct didn't match Juju's actual behavior
- Capture peer unit status in app status. 
- Unify the UnitStatus and RelationStatus structs. This was one of #34 's review comment. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
