### PR TITLE
feat: pass state by value [goopstest]

### DIFF
--- a/goopstest/README.md
+++ b/goopstest/README.md
@@ -52,8 +52,12 @@ func TestCharm(t *testing.T) {
 	}
 
 	// Assert
-	if stateOut.UnitStatus.Name != goopstest.StatusBlocked {
-		t.Errorf("Expected unit status to be %s, got %s", goopstest.StatusBlocked, stateOut.UnitStatus.Name)
+	expectedStatus := goopstest.Status{
+		Name:    goopstest.StatusBlocked,
+		Message: "Unit is not a leader",
+	}
+	if stateOut.UnitStatus != expectedStatus {
+		t.Errorf("Expected unit status %v, got %v", expectedStatus, stateOut.UnitStatus)
 	}
 }
 ```

--- a/goopstest/README.md
+++ b/goopstest/README.md
@@ -41,7 +41,7 @@ func TestCharm(t *testing.T) {
 		Charm: Configure,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 	}
 
@@ -138,7 +138,7 @@ func TestCharm(t *testing.T) {
 
 	defer os.RemoveAll(dname)
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",

--- a/goopstest/action_test.go
+++ b/goopstest/action_test.go
@@ -53,7 +53,7 @@ func TestCharmActionName(t *testing.T) {
 				Charm: tc.handler,
 			}
 
-			stateIn := &goopstest.State{}
+			stateIn := goopstest.State{}
 
 			stateOut, err := ctx.RunAction(tc.actionName, stateIn, nil)
 			if err != nil {
@@ -85,7 +85,7 @@ func TestCharmActionResults1(t *testing.T) {
 		Charm: ActionResults1,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.RunAction("run-action", stateIn, nil)
 	if err != nil {
@@ -117,7 +117,7 @@ func TestCharmActionResults3(t *testing.T) {
 		Charm: ActionResults3,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.RunAction("run-action", stateIn, nil)
 	if err != nil {
@@ -151,7 +151,7 @@ func TestCharmActionFailed(t *testing.T) {
 		Charm: ActionFailed,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.RunAction("run-action", stateIn, nil)
 	if err != nil {
@@ -202,7 +202,7 @@ func TestCharmActionParameters(t *testing.T) {
 		Charm: GetActionParamsAndSetResults,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.RunAction("run-action", stateIn, map[string]any{
 		"email":      "expected-value",
@@ -222,7 +222,7 @@ func TestCharmActionParameterNotSet(t *testing.T) {
 		Charm: GetActionParamsAndSetResults,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.RunAction("run-action", stateIn, nil)
 	if err != nil {
@@ -258,7 +258,7 @@ func TestGetActionParamInNonActionHook(t *testing.T) {
 		Charm: ActionParams,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.Run("start", stateIn)
 	if err != nil {
@@ -288,7 +288,7 @@ func TestActionFailfInNonActionHook(t *testing.T) {
 		Charm: ActionFailf,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.Run("start", stateIn)
 	if err != nil {
@@ -318,7 +318,7 @@ func TestActionLogfInNonActionHook(t *testing.T) {
 		Charm: ActionLogf,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.Run("start", stateIn)
 	if err != nil {
@@ -352,7 +352,7 @@ func TestSetActionResultsInNonActionHook(t *testing.T) {
 		Charm: SetActionResults,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.Run("start", stateIn)
 	if err != nil {

--- a/goopstest/application_version_test.go
+++ b/goopstest/application_version_test.go
@@ -21,7 +21,7 @@ func TestCharmApplicationVersion(t *testing.T) {
 		Charm: ApplicationVersion,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	stateOut, err := ctx.Run("start", stateIn)
 	if err != nil {
@@ -38,7 +38,7 @@ func TestCharmApplicationVersionInActionHook(t *testing.T) {
 		Charm: ApplicationVersion,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	stateOut, err := ctx.RunAction("run-action", stateIn, nil)
 	if err != nil {

--- a/goopstest/command_runner.go
+++ b/goopstest/command_runner.go
@@ -15,8 +15,8 @@ type fakeCommandRunner struct {
 	Args               []string
 	Output             []byte
 	Err                error
-	UnitStatus         *Status
-	AppStatus          *Status
+	UnitStatus         Status
+	AppStatus          Status
 	Leader             bool
 	Config             map[string]any
 	Secrets            []*Secret
@@ -123,12 +123,12 @@ func (f *fakeCommandRunner) handleStatusSet(args []string) {
 			return
 		}
 
-		f.AppStatus = &Status{
+		f.AppStatus = Status{
 			Name:    StatusName(args[1]),
 			Message: strings.Join(args[2:], " "),
 		}
 	} else {
-		f.UnitStatus = &Status{
+		f.UnitStatus = Status{
 			Name:    StatusName(args[0]),
 			Message: strings.Join(args[1:], " "),
 		}

--- a/goopstest/config_test.go
+++ b/goopstest/config_test.go
@@ -93,7 +93,7 @@ func TestCharmConfig(t *testing.T) {
 				tc.key: tc.value,
 			}
 
-			stateIn := &goopstest.State{
+			stateIn := goopstest.State{
 				Config: config,
 			}
 
@@ -122,7 +122,7 @@ func TestActiveIfExpectedConfigInActionHook(t *testing.T) {
 		"whatever_key": "expected",
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Config: config,
 	}
 

--- a/goopstest/containers_test.go
+++ b/goopstest/containers_test.go
@@ -90,7 +90,7 @@ func TestContainerCantConnect(t *testing.T) {
 				Charm: tt.fn,
 			}
 
-			stateIn := &goopstest.State{
+			stateIn := goopstest.State{
 				Containers: []*goopstest.Container{
 					{
 						Name:       "example",
@@ -123,7 +123,7 @@ func TestContainerCanConnect(t *testing.T) {
 		Charm: ContainerCanConnect,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",
@@ -210,7 +210,7 @@ func TestContainerGetPebblePlan(t *testing.T) {
 		Charm: ContainerGetPebblePlan,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",
@@ -243,7 +243,7 @@ func TestContainerUnexistantGetPebblePlan(t *testing.T) {
 		Charm: ContainerGetPebblePlan,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",
@@ -297,7 +297,7 @@ func TestContainerAddPebbleLayer(t *testing.T) {
 		Charm: ContainerAddPebbleLayer,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",
@@ -367,7 +367,7 @@ func TestContainerStartPebbleService(t *testing.T) {
 		Charm: ConatainerStartPebbleService,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",
@@ -436,7 +436,7 @@ func TestContainerGetPebbleServiceStatus(t *testing.T) {
 		Charm: ContainerGetPebbleServiceStatus,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",
@@ -501,7 +501,7 @@ func TestContainerStopPebbleService(t *testing.T) {
 		Charm: ContainerStopPebbleService,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",
@@ -558,7 +558,7 @@ func TestContainerRestartPebbleService(t *testing.T) {
 		Charm: ContainerRestartPebbleService,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",
@@ -636,7 +636,7 @@ func TestContainerPushFile(t *testing.T) {
 
 	defer os.RemoveAll(dname)
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",
@@ -719,7 +719,7 @@ func TestContainerPullFile(t *testing.T) {
 		t.Fatalf("failed to copy file contents to %s: %v", tempLocation, err)
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",
@@ -800,7 +800,7 @@ func TestMultiContainer(t *testing.T) {
 				Charm: MultiContainer,
 			}
 
-			stateIn := &goopstest.State{
+			stateIn := goopstest.State{
 				Containers: []*goopstest.Container{
 					{
 						Name:       "example1",

--- a/goopstest/context.go
+++ b/goopstest/context.go
@@ -32,9 +32,9 @@ type Context struct {
 	CharmErr      error
 }
 
-func (c *Context) Run(hookName string, state *State) (*State, error) {
+func (c *Context) Run(hookName string, state State) (State, error) {
 	if c.Charm == nil {
-		return nil, fmt.Errorf("charm function is not set in the context")
+		return State{}, fmt.Errorf("charm function is not set in the context")
 	}
 
 	setRelationIDs(state.Relations)
@@ -106,7 +106,7 @@ func (c *Context) Run(hookName string, state *State) (*State, error) {
 	return state, nil
 }
 
-func (c *Context) RunAction(actionName string, state *State, params map[string]any) (*State, error) {
+func (c *Context) RunAction(actionName string, state State, params map[string]any) (State, error) {
 	fakeCommandRunner := &fakeCommandRunner{
 		Output:           []byte(``),
 		Err:              nil,

--- a/goopstest/context.go
+++ b/goopstest/context.go
@@ -48,8 +48,9 @@ func (c *Context) Run(hookName string, state State) (State, error) {
 		}
 	}
 
-	if state.UnitStatus == nil {
-		state.UnitStatus = &Status{
+	nilStatus := Status{}
+	if state.UnitStatus == nilStatus {
+		state.UnitStatus = Status{
 			Name: StatusUnknown,
 		}
 	}

--- a/goopstest/docs_test.go
+++ b/goopstest/docs_test.go
@@ -47,8 +47,12 @@ func TestCharmBasic(t *testing.T) {
 	}
 
 	// Assert
-	if stateOut.UnitStatus.Name != goopstest.StatusBlocked {
-		t.Errorf("Expected unit status to be %s, got %s", goopstest.StatusBlocked, stateOut.UnitStatus.Name)
+	expectedStatus := goopstest.Status{
+		Name:    goopstest.StatusBlocked,
+		Message: "Unit is not a leader",
+	}
+	if stateOut.UnitStatus != expectedStatus {
+		t.Errorf("Expected unit status %v, got %v", expectedStatus, stateOut.UnitStatus)
 	}
 }
 

--- a/goopstest/docs_test.go
+++ b/goopstest/docs_test.go
@@ -36,7 +36,7 @@ func TestCharmBasic(t *testing.T) {
 		Charm: ConfigureBasic,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 	}
 
@@ -115,7 +115,7 @@ func TestCharmKubernetes(t *testing.T) {
 
 	defer os.RemoveAll(dname)
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Containers: []*goopstest.Container{
 			{
 				Name:       "example",

--- a/goopstest/env_test.go
+++ b/goopstest/env_test.go
@@ -52,7 +52,7 @@ func TestGetModelInfo(t *testing.T) {
 		UUID: "12345678-1234-5678-1234-567812345678",
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Model: model,
 	}
 
@@ -77,7 +77,7 @@ func TestGetUnitName(t *testing.T) {
 		UnitID:  "blou/0",
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.Run("start", stateIn)
 	if err != nil {
@@ -91,7 +91,7 @@ func TestGetJujuVersion(t *testing.T) {
 		JujuVersion: "1.2.3",
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.Run("start", stateIn)
 	if err != nil {

--- a/goopstest/hook_test.go
+++ b/goopstest/hook_test.go
@@ -68,7 +68,7 @@ func TestCharmHookName(t *testing.T) {
 				Charm: tc.handler,
 			}
 
-			stateIn := &goopstest.State{}
+			stateIn := goopstest.State{}
 
 			stateOut, err := ctx.Run(tc.hookName, stateIn)
 			if err != nil {

--- a/goopstest/leader_test.go
+++ b/goopstest/leader_test.go
@@ -79,7 +79,7 @@ func TestCharmLeader(t *testing.T) {
 				Charm: tc.handler,
 			}
 
-			stateIn := &goopstest.State{
+			stateIn := goopstest.State{
 				Leader: tc.leader,
 			}
 

--- a/goopstest/log_test.go
+++ b/goopstest/log_test.go
@@ -18,7 +18,7 @@ func TestContainerLog(t *testing.T) {
 		Charm: ContainerLog,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.Run("install", stateIn)
 	if err != nil {

--- a/goopstest/metadata_test.go
+++ b/goopstest/metadata_test.go
@@ -53,7 +53,7 @@ func TestGetMetadata(t *testing.T) {
 		Charm: GetMetadata,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.Run("install", stateIn)
 	if err != nil {

--- a/goopstest/peer_relation_test.go
+++ b/goopstest/peer_relation_test.go
@@ -43,7 +43,7 @@ func TestGetRelationIDsForPeers(t *testing.T) {
 		PeersData: peersData,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		PeerRelations: []*goopstest.PeerRelation{
 			peerRelation,
 		},
@@ -70,7 +70,7 @@ func TestGetRelationIDsNoPeers(t *testing.T) {
 		UnitID:  "example/0",
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		PeerRelations: []*goopstest.PeerRelation{},
 	}
 
@@ -112,7 +112,7 @@ func TestListPeerRelationUnits(t *testing.T) {
 		UnitID:  "example/0",
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		PeerRelations: []*goopstest.PeerRelation{
 			{
 				ID:        "example-peer:0",
@@ -155,7 +155,7 @@ func TestGetPeerRelationModelUUID(t *testing.T) {
 		UnitID:  "example/0",
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		PeerRelations: []*goopstest.PeerRelation{
 			{
 				ID: "example-peer:0",
@@ -213,7 +213,7 @@ func TestGetSelfUnitPeerRelationData(t *testing.T) {
 				UnitID:  "example/0",
 			}
 
-			stateIn := &goopstest.State{
+			stateIn := goopstest.State{
 				Leader: tc.leader,
 				PeerRelations: []*goopstest.PeerRelation{
 					{
@@ -257,7 +257,7 @@ func TestGetOtherUnitPeerRelationData(t *testing.T) {
 				UnitID:  "example/1",
 			}
 
-			stateIn := &goopstest.State{
+			stateIn := goopstest.State{
 				Leader: tc.leader,
 				PeerRelations: []*goopstest.PeerRelation{
 					{
@@ -321,7 +321,7 @@ func TestGetAppPeerRelationData(t *testing.T) {
 				UnitID:  "example-peer/0",
 			}
 
-			stateIn := &goopstest.State{
+			stateIn := goopstest.State{
 				Leader: tc.leader,
 				PeerRelations: []*goopstest.PeerRelation{
 					{
@@ -356,7 +356,7 @@ func TestGetAppPeerRelationDataNoRelation(t *testing.T) {
 		UnitID:  "example-peer/0",
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		PeerRelations: []*goopstest.PeerRelation{},
 	}
 
@@ -395,7 +395,7 @@ func TestSetPeerUnitRelationData(t *testing.T) {
 		UnitID:  "example/0",
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		PeerRelations: []*goopstest.PeerRelation{
 			{
 				ID: "example-peer:0",
@@ -441,7 +441,7 @@ func TestSetPeerAppRelationDataLeader(t *testing.T) {
 		UnitID:  "example-peer/0",
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		PeerRelations: []*goopstest.PeerRelation{
 			{
@@ -475,7 +475,7 @@ func TestSetPeerAppRelationDataNonLeader(t *testing.T) {
 		UnitID:  "example-peer/0",
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 		PeerRelations: []*goopstest.PeerRelation{
 			{

--- a/goopstest/ports_test.go
+++ b/goopstest/ports_test.go
@@ -26,7 +26,7 @@ func TestSetPorts(t *testing.T) {
 		Charm: SetPorts,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	stateOut, err := ctx.Run("start", stateIn)
 	if err != nil {
@@ -51,7 +51,7 @@ func TestSetPortsAlreadySet(t *testing.T) {
 		Charm: SetPorts,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Ports: []*goopstest.Port{
 			{
 				Port:     80,
@@ -83,7 +83,7 @@ func TestSetPortsDifferentSet(t *testing.T) {
 		Charm: SetPorts,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Ports: []*goopstest.Port{
 			{
 				Port:     81,
@@ -124,7 +124,7 @@ func TestCloseUnOpenedPort(t *testing.T) {
 		Charm: ClosePort,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Ports: []*goopstest.Port{
 			{
 				Port:     81,
@@ -169,7 +169,7 @@ func TestOpenOpenedPort(t *testing.T) {
 		Charm: OpenPort,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Ports: []*goopstest.Port{
 			{
 				Port:     81,

--- a/goopstest/relation_test.go
+++ b/goopstest/relation_test.go
@@ -34,7 +34,7 @@ func TestCharmGetRelationIDs(t *testing.T) {
 	certRelation := &goopstest.Relation{
 		Endpoint: "certificates",
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			certRelation,
 		},
@@ -64,7 +64,7 @@ func TestCharmGetRelationIDsNoRelation(t *testing.T) {
 		Charm: GetRelationIDsNoRelation,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	stateOut, err := ctx.Run("start", stateIn)
 	if err != nil {
@@ -90,7 +90,7 @@ func TestCharmGetRelationIDsNoName(t *testing.T) {
 		Charm: GetRelationIDsNoName,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.Run("start", stateIn)
 	if err != nil {
@@ -125,7 +125,7 @@ func TestCharmGetRelationIDsNoResult(t *testing.T) {
 		Charm: GetRelationIDsNoResult,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	_, err := ctx.Run("start", stateIn)
 	if err != nil {
@@ -222,7 +222,7 @@ func TestCharmListRelationUnits(t *testing.T) {
 			RemoteAppName:   "provider",
 			RemoteUnitsData: remoteUnitsData,
 		}
-		stateIn := &goopstest.State{
+		stateIn := goopstest.State{
 			Relations: []*goopstest.Relation{
 				certRelation,
 			},
@@ -244,7 +244,7 @@ func TestListRelationUnitsResultNotFound(t *testing.T) {
 		Charm: ListRelationUnits1Result,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{},
 	}
 
@@ -277,7 +277,7 @@ func TestListRelationUnitsInActionHook(t *testing.T) {
 		RemoteAppName:   "provider",
 		RemoteUnitsData: remoteUnitsData,
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			certRelation,
 		},
@@ -331,7 +331,7 @@ func TestCharmGetRemoteUnitRelationData(t *testing.T) {
 		RemoteAppName:   "provider",
 		RemoteUnitsData: remoteUnitsData,
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			certRelation,
 		},
@@ -352,7 +352,7 @@ func TestCharmGetRemoteUnitRelationDataNoRelation(t *testing.T) {
 		Charm: GetRemoteUnitRelationData,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{},
 	}
 
@@ -376,7 +376,7 @@ func TestCharmGetRemoteUnitRelationDataNoRemoteUnit(t *testing.T) {
 		Charm: GetRemoteUnitRelationData,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			{
 				Endpoint:      "certificates",
@@ -410,7 +410,7 @@ func TestCharmGetRemoteUnitRelationDataNoData(t *testing.T) {
 		Charm: GetRemoteUnitRelationData,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			{
 				Endpoint:      "certificates",
@@ -472,7 +472,7 @@ func TestCharmGetLocalUnitRelationData(t *testing.T) {
 			"certificate_signing_requests": "csr-data",
 		},
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			certRelation,
 		},
@@ -502,7 +502,7 @@ func TestGetOtherLocalUnitRelationData(t *testing.T) {
 			"certificate_signing_requests": "csr-data",
 		},
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			certRelation,
 		},
@@ -536,7 +536,7 @@ func TestGetOtherUnexistantLocalUnitRelationData(t *testing.T) {
 			"certificate_signing_requests": "csr-data",
 		},
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			certRelation,
 		},
@@ -593,7 +593,7 @@ func TestCharmGetRemoteAppRelationData(t *testing.T) {
 		RemoteAppName: "provider",
 		RemoteAppData: remoteAppData,
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			certRelation,
 		},
@@ -614,7 +614,7 @@ func TestCharmGetRemoteAppRelationDataNoRelation(t *testing.T) {
 		Charm: GetRemoteAppRelationData,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{},
 	}
 
@@ -668,7 +668,7 @@ func TestCharmGetLocalAppRelationData(t *testing.T) {
 			"certificate_signing_requests": "csr-data",
 		},
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		Relations: []*goopstest.Relation{
 			certRelation,
@@ -703,7 +703,7 @@ func TestCharmGetLocalAppRelationDataNonLeader(t *testing.T) {
 			"certificate_signing_requests": "csr-data",
 		},
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 		Relations: []*goopstest.Relation{
 			certRelation,
@@ -746,7 +746,7 @@ func TestCharmSetUnitRelationData(t *testing.T) {
 	certRelation := &goopstest.Relation{
 		Endpoint: "certificates",
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			certRelation,
 		},
@@ -792,7 +792,7 @@ func TestCharmSetAppRelationData(t *testing.T) {
 	certRelation := &goopstest.Relation{
 		Endpoint: "certificates",
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		Relations: []*goopstest.Relation{
 			certRelation,
@@ -827,7 +827,7 @@ func TestCharmSetAppRelationDataNoRelation(t *testing.T) {
 		Charm: SetAppRelationData,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader:    true,
 		Relations: []*goopstest.Relation{},
 	}
@@ -858,7 +858,7 @@ func TestCharmSetAppRelationDataNonLeader(t *testing.T) {
 	certRelation := &goopstest.Relation{
 		Endpoint: "certificates",
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 		Relations: []*goopstest.Relation{
 			certRelation,
@@ -961,7 +961,7 @@ func TestCharmSetAppRelationData2(t *testing.T) {
 	certRelation := &goopstest.Relation{
 		Endpoint: "metrics",
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		Relations: []*goopstest.Relation{
 			certRelation,
@@ -1048,7 +1048,7 @@ func TestCharmRelationEndToEnd(t *testing.T) {
 		RemoteAppName:   "provider",
 		RemoteUnitsData: remoteUnitsData,
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			certRelation,
 		},
@@ -1085,7 +1085,7 @@ func TestCharmRelationModelGetUUID(t *testing.T) {
 	certRelation := &goopstest.Relation{
 		Endpoint: "certificates",
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			certRelation,
 		},
@@ -1113,7 +1113,7 @@ func TestCharmRelationModelGetUUIDWithRemoteModelUUID(t *testing.T) {
 		Endpoint:        "certificates",
 		RemoteModelUUID: "a4e65ff5-2358-4595-8ace-cc820c120e24",
 	}
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{
 			certRelation,
 		},
@@ -1137,7 +1137,7 @@ func TestCharmRelationModelGetUUIDNoRelation(t *testing.T) {
 		Charm: RelationModelGetUUID,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Relations: []*goopstest.Relation{},
 		Model: &goopstest.Model{
 			UUID: "a4e65ff5-2358-4595-8ace-cc820c120e24",

--- a/goopstest/secret_test.go
+++ b/goopstest/secret_test.go
@@ -73,7 +73,7 @@ func TestCharmGetSecretByLabel(t *testing.T) {
 				},
 			}
 
-			stateIn := &goopstest.State{
+			stateIn := goopstest.State{
 				Secrets: []*goopstest.Secret{
 					mySecret,
 				},
@@ -105,7 +105,7 @@ func TestCharmGetUnexistingSecretByLabel(t *testing.T) {
 		Charm: GetSecretByLabel,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	stateOut, err := ctx.Run("start", stateIn)
 	if err != nil {
@@ -184,7 +184,7 @@ func TestCharmGetSecretByID(t *testing.T) {
 				},
 			}
 
-			stateIn := &goopstest.State{
+			stateIn := goopstest.State{
 				Secrets: []*goopstest.Secret{
 					mySecret,
 				},
@@ -242,7 +242,7 @@ func TestCharmAddAppSecret(t *testing.T) {
 		Charm: AddAppSecret,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 	}
 
@@ -253,6 +253,10 @@ func TestCharmAddAppSecret(t *testing.T) {
 
 	if ctx.CharmErr != nil {
 		t.Fatalf("Run returned an error: %v", ctx.CharmErr)
+	}
+
+	if len(stateIn.Secrets) != 0 {
+		t.Fatalf("expected no secrets in input state, got %d", len(stateIn.Secrets))
 	}
 
 	if len(stateOut.Secrets) != 1 {
@@ -278,7 +282,7 @@ func TestCharmAddAppSecretNonLeader(t *testing.T) {
 		Charm: AddAppSecret,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 	}
 
@@ -327,7 +331,7 @@ func TestCharmAddUnitSecretNonLeader(t *testing.T) {
 		Charm: AddUnitSecret,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 	}
 
@@ -388,7 +392,7 @@ func TestCharmRemoveSecret(t *testing.T) {
 		Charm: RemoveSecret,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		Secrets: []*goopstest.Secret{
 			{
@@ -416,7 +420,7 @@ func TestCharmRemoveSecretNonLeader(t *testing.T) {
 		Charm: RemoveSecret,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 		Secrets: []*goopstest.Secret{
 			{
@@ -448,7 +452,7 @@ func TestCharmRemoveUnexistingSecret(t *testing.T) {
 		Charm: RemoveSecret,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Secrets: []*goopstest.Secret{
 			{
 				ID: "12345",
@@ -496,7 +500,7 @@ func TestCharmGetSecretInfoByID(t *testing.T) {
 		Charm: GetSecretInfoByID,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Secrets: []*goopstest.Secret{
 			{
 				ID: "12345",
@@ -528,7 +532,7 @@ func TestCharmGetSecretInfoByIDNonLeader(t *testing.T) {
 		Charm: GetSecretInfoByID,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 		Secrets: []*goopstest.Secret{
 			{
@@ -560,7 +564,7 @@ func TestCharmGetUnitSecretInfoByNonLeader(t *testing.T) {
 		Charm: GetSecretInfoByID,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Secrets: []*goopstest.Secret{
 			{
 				ID: "12345",
@@ -610,7 +614,7 @@ func TestCharmGetSecretInfoByLabel(t *testing.T) {
 		Charm: GetSecretInfoByLabel,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		Secrets: []*goopstest.Secret{
 			{
@@ -638,7 +642,7 @@ func TestCharmGetSecretInfoByLabelNonLeader(t *testing.T) {
 		Charm: GetSecretInfoByLabel,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 		Secrets: []*goopstest.Secret{
 			{
@@ -670,7 +674,7 @@ func TestCharmGetUnitSecretInfoByLabelNonLeader(t *testing.T) {
 		Charm: GetSecretInfoByLabel,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 		Secrets: []*goopstest.Secret{
 			{
@@ -718,7 +722,7 @@ func TestCharmGetSecretIDs(t *testing.T) {
 		Charm: GetSecretIDs,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		Secrets: []*goopstest.Secret{
 			{
@@ -761,7 +765,7 @@ func TestCharmGetSecretIDsNonLeader(t *testing.T) {
 		Charm: GetSecretIDs,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 		Secrets: []*goopstest.Secret{
 			{
@@ -814,7 +818,7 @@ func TestCharmGrantSecretToRelation(t *testing.T) {
 		Charm: GrantSecretToRelation,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		Secrets: []*goopstest.Secret{
 			{
@@ -861,7 +865,7 @@ func TestCharmGrantSecretToUnit(t *testing.T) {
 		Charm: GrantSecretToUnit,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		Secrets: []*goopstest.Secret{
 			{
@@ -893,7 +897,7 @@ func TestCharmGrantSecretNonLeader(t *testing.T) {
 		Charm: GrantSecretToRelation,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 		Secrets: []*goopstest.Secret{
 			{
@@ -943,7 +947,7 @@ func TestCharmSetSecret(t *testing.T) {
 		Charm: SetSecret,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		Secrets: []*goopstest.Secret{
 			{
@@ -1001,7 +1005,7 @@ func TestCharmSetSecretNonLeader(t *testing.T) {
 		Charm: SetSecret,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 		Secrets: []*goopstest.Secret{
 			{
@@ -1058,7 +1062,7 @@ func TestCharmRevokeSecret(t *testing.T) {
 		Charm: RevokeSecret,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		Secrets: []*goopstest.Secret{
 			{

--- a/goopstest/state.go
+++ b/goopstest/state.go
@@ -101,8 +101,8 @@ type Status struct {
 
 type State struct {
 	Leader             bool
-	UnitStatus         *Status
-	AppStatus          *Status
+	UnitStatus         Status
+	AppStatus          Status
 	Config             map[string]any
 	Secrets            []*Secret
 	ApplicationVersion string

--- a/goopstest/state_test.go
+++ b/goopstest/state_test.go
@@ -26,7 +26,7 @@ func TestGetState(t *testing.T) {
 		Charm: GetState,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		StoredState: map[string]string{
 			"my-key": "my-value",
 		},
@@ -52,7 +52,7 @@ func TestSetState(t *testing.T) {
 		Charm: SetState,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	stateOut, err := ctx.Run("start", stateIn)
 	if err != nil {
@@ -96,7 +96,7 @@ func TestGetSetState(t *testing.T) {
 		Charm: GetSetState,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		StoredState: map[string]string{
 			"my-key": "my-value",
 		},
@@ -126,7 +126,7 @@ func TestDeleteState(t *testing.T) {
 		Charm: DeleteState,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		StoredState: map[string]string{
 			"my-key": "my-value",
 		},

--- a/goopstest/status_test.go
+++ b/goopstest/status_test.go
@@ -84,7 +84,7 @@ func TestCharmSetUnitStatus(t *testing.T) {
 				Charm: tc.handler,
 			}
 
-			stateIn := &goopstest.State{}
+			stateIn := goopstest.State{}
 
 			stateOut, err := ctx.Run(tc.hookName, stateIn)
 			if err != nil {
@@ -103,7 +103,7 @@ func TestCharmSetUnitStatusPreset(t *testing.T) {
 		Charm: SetUnitStatusMaintenance,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		UnitStatus: &goopstest.Status{
 			Name: goopstest.StatusActive,
 		},
@@ -198,7 +198,7 @@ func TestSetAppStatusLeader(t *testing.T) {
 				Charm: tc.handler,
 			}
 
-			stateIn := &goopstest.State{
+			stateIn := goopstest.State{
 				Leader: true, // Assume we are the leader for setting app status
 			}
 
@@ -219,7 +219,7 @@ func TestCharmAppStatusPreset(t *testing.T) {
 		Charm: SetAppStatusMaintenance,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		AppStatus: &goopstest.Status{
 			Name: goopstest.StatusActive,
@@ -262,7 +262,7 @@ func TestGetUnitStatus(t *testing.T) {
 		Charm: GetUnitStatus,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		UnitStatus: &goopstest.Status{
 			Name:    goopstest.StatusActive,
 			Message: "My expected message",
@@ -305,7 +305,7 @@ func TestGetUnitStatusNotSet(t *testing.T) {
 		Charm: GetUnitStatusUnknown,
 	}
 
-	stateIn := &goopstest.State{}
+	stateIn := goopstest.State{}
 
 	stateOut, err := ctx.Run("install", stateIn)
 	if err != nil {
@@ -347,7 +347,7 @@ func TestGetAppStatusLeader(t *testing.T) {
 		Charm: GetAppStatus,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: true,
 		AppStatus: &goopstest.Status{
 			Name:    goopstest.StatusActive,
@@ -378,7 +378,7 @@ func TestGetAppStatusNonLeader(t *testing.T) {
 		Charm: GetAppStatus,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 		AppStatus: &goopstest.Status{
 			Name:    goopstest.StatusActive,
@@ -414,7 +414,7 @@ func TestSetAppStatusNonLeader(t *testing.T) {
 		Charm: SetAppStatusActive,
 	}
 
-	stateIn := &goopstest.State{
+	stateIn := goopstest.State{
 		Leader: false,
 	}
 

--- a/goopstest/status_test.go
+++ b/goopstest/status_test.go
@@ -104,7 +104,7 @@ func TestCharmSetUnitStatusPreset(t *testing.T) {
 	}
 
 	stateIn := goopstest.State{
-		UnitStatus: &goopstest.Status{
+		UnitStatus: goopstest.Status{
 			Name: goopstest.StatusActive,
 		},
 	}
@@ -221,7 +221,7 @@ func TestCharmAppStatusPreset(t *testing.T) {
 
 	stateIn := goopstest.State{
 		Leader: true,
-		AppStatus: &goopstest.Status{
+		AppStatus: goopstest.Status{
 			Name: goopstest.StatusActive,
 		},
 	}
@@ -263,7 +263,7 @@ func TestGetUnitStatus(t *testing.T) {
 	}
 
 	stateIn := goopstest.State{
-		UnitStatus: &goopstest.Status{
+		UnitStatus: goopstest.Status{
 			Name:    goopstest.StatusActive,
 			Message: "My expected message",
 		},
@@ -349,7 +349,7 @@ func TestGetAppStatusLeader(t *testing.T) {
 
 	stateIn := goopstest.State{
 		Leader: true,
-		AppStatus: &goopstest.Status{
+		AppStatus: goopstest.Status{
 			Name:    goopstest.StatusActive,
 			Message: "My expected message",
 		},
@@ -380,7 +380,7 @@ func TestGetAppStatusNonLeader(t *testing.T) {
 
 	stateIn := goopstest.State{
 		Leader: false,
-		AppStatus: &goopstest.Status{
+		AppStatus: goopstest.Status{
 			Name:    goopstest.StatusActive,
 			Message: "My expected message",
 		},


### PR DESCRIPTION
# Description

Pass state by value. It didn't make sense to have `stateOut, err := ctx.Run("event", stateIn)` and have the sate being passed by reference, in the end both stateIn and stateOut were the same object. Here we pass the state by value, meaning stateIn and stateOut are 2 different objects. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
