### PR TITLE
docs: add how-to manage workloads on k8s

### DIFF
--- a/docs/explanation/design_principles.md
+++ b/docs/explanation/design_principles.md
@@ -12,4 +12,4 @@ Charms are meant to be deployed at scale, in production environments, and in mis
 
 ## 2. Simplicity
 
-`goops` serves as a minimal mapping between Juju and Go constructs. Goops is not a framework; it does not impose charm design patterns. You call `goops`, it does not call you.
+`goops` serves as a minimal mapping between Juju and Go constructs. `goops` is not a framework; it does not impose charm design patterns. You call `goops`, it does not call you.

--- a/docs/explanation/unit_testing.md
+++ b/docs/explanation/unit_testing.md
@@ -6,15 +6,21 @@ description: Unit testing for `goops` charms.
 
 `goopstest` is a unit testing framework for `goops` charms. It allows you to simulate Juju environments and test your charm logic without needing a live Juju controller.
 
-`goopstest` allows users to write unit tests in a "state-transition" style. Each test consists of:
+`goopstest` allows users to write unit tests in a "state-transition" style. Each test includes:
 
-- A Context and an initial state (Arrange)
-- An event (Act)
-- An output state (Assert)
+- **Context**: Charm function under test, Juju version, and other relevant context information.
+- **State**: Resources accessible to the charm, including status, leadership, configuration, relations.
+- **Event**: Hook name that will be run (ex. `install`, `start`, `stop`, etc.).
+
+Charm developers are expected to write tests that follow the *Arrange-Act-Assert* pattern:
+
+- **Arrange**: Declare the context and input state.
+- **Act**: Execute a hook.
+- **Assert**: Verify that the output state matches the expected state.
 
 ## Examples
 
-### A basic charm
+### Example 1: A basic charm
 
 Here's an example of a simple charm that uses `goops` to check if the unit is a leader and set its status accordingly:
 
@@ -75,7 +81,7 @@ func TestCharm(t *testing.T) {
 }
 ```
 
-### A Kubernetes charm
+### Example 2: A Kubernetes charm
 
 Here's a Kubernetes charm example that uses `goops` to configure a Pebble service and start it:
 

--- a/docs/explanation/unit_testing.md
+++ b/docs/explanation/unit_testing.md
@@ -6,7 +6,7 @@ description: Unit testing for `goops` charms.
 
 `goopstest` is a unit testing framework for `goops` charms. It allows you to simulate Juju environments and test your charm logic without needing a live Juju controller.
 
-`goopstest` allows users to write unit tests in a "state-transition" style. Each test includes:
+`goopstest` allows users to write unit tests in a "state-transition" style. Each test includes the following concepts:
 
 - **Context**: Charm function under test, Juju version, and other relevant context information.
 - **State**: Resources accessible to the charm, including status, leadership, configuration, relations.

--- a/docs/how_to/build_a_charm.md
+++ b/docs/how_to/build_a_charm.md
@@ -2,7 +2,7 @@
 description: Build a `goops` charm.
 ---
 
-# Build a Charm
+# How-to build a Charm
 
 ## 1. Create a `charmcraft.yaml` file with the Go plugin
 

--- a/docs/how_to/manage/actions.md
+++ b/docs/how_to/manage/actions.md
@@ -2,7 +2,7 @@
 description: Manage action with `goops` charms.
 ---
 
-# Manage actions
+# How-to manage actions
 
 Juju users can run actions in charms using the `juju run` command. Here we cover how you can use `goops` to handle those actions in your charm.
 

--- a/docs/how_to/manage/config.md
+++ b/docs/how_to/manage/config.md
@@ -2,7 +2,7 @@
 description: Manage config with `goops` charms.
 ---
 
-# Manage config
+# How-to manage config
 
 Juju users can configure charms using the `juju config` command. Here we cover how you can use `goops` to read those configuration options in your charm.
 

--- a/docs/how_to/manage/index.md
+++ b/docs/how_to/manage/index.md
@@ -7,5 +7,6 @@ These guides cover how to manage the following charm resources using `goops`:
 - [Secrets](secrets.md)
 - [Actions](actions.md)
 - [State](state.md)
+- [Workloads (on Kubernetes)](workloads_on_k8s.md)
 
 Using `goops`, you can also manage other resources not listed here (ex. Ports, Storage). For more information on managing those resources, refer to the [API Documentation :octicons-link-external-24:](https://pkg.go.dev/github.com/gruyaume/goops).

--- a/docs/how_to/manage/index.md
+++ b/docs/how_to/manage/index.md
@@ -1,6 +1,6 @@
 # How-to: Manage charm resources
 
-These guides cover how to manage the following charm resources using `goops`:
+These guides cover how to manage commonly used charm resources using `goops`:
 
 - [Integrations](integrations.md)
 - [Config](config.md)
@@ -9,4 +9,4 @@ These guides cover how to manage the following charm resources using `goops`:
 - [State](state.md)
 - [Workloads (on Kubernetes)](workloads_on_k8s.md)
 
-Using `goops`, you can also manage other resources not listed here (ex. Ports, Storage). For more information on managing those resources, refer to the [API Documentation :octicons-link-external-24:](https://pkg.go.dev/github.com/gruyaume/goops).
+You can also manage other resources not listed here (ex. ports, storage). For more information on managing those resources, refer to the [goops API Documentation :octicons-link-external-24:](https://pkg.go.dev/github.com/gruyaume/goops).

--- a/docs/how_to/manage/integrations.md
+++ b/docs/how_to/manage/integrations.md
@@ -2,7 +2,7 @@
 description: Manage integrations with `goops` charms.
 ---
 
-# Manage integrations
+# How-to manage integrations
 
 Integrations are a core part of Juju, allowing charms to connect and share data with each other. Here we cover how you can use `goops` to manage integrations.
 
@@ -26,7 +26,27 @@ requires:
 
 You can manage relation data in two ways: directly using `goops` functions or indirectly using Charm Libraries.
 
-### Option 1: Directly
+### Option 1: Using Charm Libraries (recommended)
+
+In most cases, charms should not directly read and write to relation data. Instead, they should do so indirectly using [Charm Libraries](../../reference/charm_libraries.md), which encapsulate the relation logic.
+
+```go
+package charm
+
+import (
+	"github.com/gruyaume/charm-libraries/postgresql"
+)
+
+func GetDatabaseURL(relationName string) (string, error) {
+	i := &postgresql.Integration{
+		RelationName: relationName,
+	}
+
+	return i.GetDatabaseURL()
+}
+```
+
+### Option 2: Directly
 
 `goops` provides functions to manage relations, allowing you to get relation IDs, list relation units, and set or get relation data. Those are the same functions that Juju exposes through hook commands.
 
@@ -82,23 +102,3 @@ func GetDatabaseURL(relationName string) (string, error) {
 
     - [Juju Hook commands :octicons-link-external-24:](https://documentation.ubuntu.com/juju/3.6/reference/hook-command/list-of-hook-commands/)
     - [goops API reference :octicons-link-external-24:](https://pkg.go.dev/github.com/gruyaume/goops)
-
-### Option 2: Using Charm Libraries
-
-In most cases, charms should not directly read and write to relation data. Instead, they should do so indirectly using [Charm Libraries](../../reference/charm_libraries.md), which encapsulate the relation logic.
-
-```go
-package charm
-
-import (
-	"github.com/gruyaume/charm-libraries/postgresql"
-)
-
-func GetDatabaseURL(relationName string) (string, error) {
-	i := &postgresql.Integration{
-		RelationName: relationName,
-	}
-
-	return i.GetDatabaseURL()
-}
-```

--- a/docs/how_to/manage/secrets.md
+++ b/docs/how_to/manage/secrets.md
@@ -2,7 +2,7 @@
 description: Manage secrets with `goops` charms.
 ---
 
-# Manage secrets
+# How-to manage secrets
 
 Both Juju users and charms can manage secrets. Here we cover how charms can read and write secrets using `goops`.
 

--- a/docs/how_to/manage/state.md
+++ b/docs/how_to/manage/state.md
@@ -2,7 +2,7 @@
 description: Manage state with `goops` charms.
 ---
 
-# Manage state
+# How-to manage state
 
 Juju allows charms to store state in a key-value store. Here we cover how you can use `goops` to set, get, and delete state in your charms. In this simple example, we check whether a state exists for a key named `my-key`. If it exists, we delete it. If it does not exist, we set it to a value of `my-value`.
 

--- a/docs/how_to/manage/workloads_on_k8s.md
+++ b/docs/how_to/manage/workloads_on_k8s.md
@@ -1,0 +1,184 @@
+---
+description: Manage workloads on Kubernetes with `goops` charms.
+---
+
+# How-to manage workloads on Kubernetes
+
+This guide covers how to manage workloads on Kubernetes using `goops`. Workloads are services that run in sidecar containers, next to the charm container. The charm uses Pebble to manage these workloads. [Pebble](https://github.com/canonical/pebble) is a lightweight Linux service manager that allows the charm to manage services, files, and health checks in the application's container.
+
+## 1. Declare containers
+
+Declare the containers in you charm's `charmcraft.yaml` file. For example:
+
+```yaml
+containers:
+  myapp:
+    resource: myapp-image
+
+resources:
+  myapp-image:
+    type: oci-image
+    description: OCI image for my application
+```
+
+!!! note
+    For more information on the `charmcraft.yaml` charm definition, read the [official charmcraft documentation](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/).
+
+## 2. Manage workloads using `goops.Pebble`
+
+You can manage workloads using the `goops.Pebble` API. In the following example, we initialize a Pebble client for the `myapp` container, push a configuration file, create a Pebble layer, and start the service.
+
+```go
+package charm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/canonical/pebble/client"
+	"github.com/gruyaume/goops"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	ConfigPath = "/etc/config.yaml"
+)
+
+type ServiceConfig struct {
+	Override string `yaml:"override"`
+	Summary  string `yaml:"summary"`
+	Command  string `yaml:"command"`
+	Startup  string `yaml:"startup"`
+}
+
+type PebbleLayer struct {
+	Summary     string                   `yaml:"summary"`
+	Description string                   `yaml:"description"`
+	Services    map[string]ServiceConfig `yaml:"services"`
+}
+
+type PebblePlan struct {
+	Services map[string]ServiceConfig `yaml:"services"`
+}
+
+func Configure() error {
+	pebble := goops.Pebble("myapp")
+
+	_, err := pebble.SysInfo()
+	if err != nil {
+		return fmt.Errorf("could not connect to pebble: %w", err)
+	}
+
+	err = syncConfig(pebble)
+	if err != nil {
+		return fmt.Errorf("could not sync config: %w", err)
+	}
+
+	err = syncPebbleService(pebble)
+	if err != nil {
+		return fmt.Errorf("could not sync pebble service: %w", err)
+	}
+
+	_ = goops.SetUnitStatus(goops.StatusActive, "service is running")
+
+	return nil
+}
+
+func syncConfig(pebble goops.PebbleClient) error {
+	expectedConfig := "Example configuration file for MyApp"
+
+	err := pebble.Push(&client.PushOptions{
+		Source: strings.NewReader(expectedConfig),
+		Path:   ConfigPath,
+	})
+	if err != nil {
+		return fmt.Errorf("could not push file: %w", err)
+	}
+
+	return nil
+}
+
+func syncPebbleService(pebble goops.PebbleClient) error {
+	if !pebbleLayerCreated(pebble) {
+		goops.LogInfof("Pebble layer not created")
+
+		err := addPebbleLayer(pebble)
+		if err != nil {
+			return fmt.Errorf("could not add pebble layer: %w", err)
+		}
+
+		goops.LogInfof("Pebble layer created")
+	}
+
+	_, err := pebble.Start(&client.ServiceOptions{
+		Names: []string{"notary"},
+	})
+	if err != nil {
+		return fmt.Errorf("could not start pebble service: %w", err)
+	}
+
+	goops.LogInfof("Pebble service started")
+
+	return nil
+}
+
+func pebbleLayerCreated(pebble goops.PebbleClient) bool {
+	dataBytes, err := pebble.PlanBytes(nil)
+	if err != nil {
+		return false
+	}
+
+	var plan PebblePlan
+
+	err = yaml.Unmarshal(dataBytes, &plan)
+	if err != nil {
+		return false
+	}
+
+	service, exists := plan.Services["myapp"]
+	if !exists {
+		return false
+	}
+
+	if service.Command != "myapp --config "+ConfigPath {
+		return false
+	}
+
+	return true
+}
+
+func addPebbleLayer(pebble goops.PebbleClient) error {
+	layerData, err := yaml.Marshal(PebbleLayer{
+		Summary:     "MyApp layer",
+		Description: "pebble config layer for MyApp",
+		Services: map[string]ServiceConfig{
+			"myapp": {
+				Override: "replace",
+				Summary:  "My App Service",
+				Command:  "myapp --config " + ConfigPath,
+				Startup:  "enabled",
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("could not marshal layer data to YAML: %w", err)
+	}
+
+	err = pebble.AddLayer(&client.AddLayerOptions{
+		Combine:   true,
+		Label:     "myapp",
+		LayerData: layerData,
+	})
+	if err != nil {
+		return fmt.Errorf("could not add pebble layer: %w", err)
+	}
+
+	return nil
+}
+```
+
+!!! info
+    Learn more about workload management in Kubernetes charms:
+
+    - [Pebble documentation :octicons-link-external-24:](https://documentation.ubuntu.com/pebble/)
+    - [goops API reference :octicons-link-external-24:](https://pkg.go.dev/github.com/gruyaume/goops)

--- a/docs/how_to/perform_other_charm_operations.md
+++ b/docs/how_to/perform_other_charm_operations.md
@@ -2,6 +2,6 @@
 description: Perform other charm operations with `goops` charms.
 ---
 
-# How-to perform Other Charm Operations
+# How-to perform other Charm operations
 
-Other charm operations such as `deploying`, `publishing`, and `upgrading` are identical to those for charms written in Python or other languages. The `goops` charm framework does not change the way you interact with Juju for these operations. For more information on these operations, refer to the [Juju documentation](https://documentation.ubuntu.com/juju/3.6/).
+Other charm operations such as `deploying`, `publishing`, and `upgrading` are identical to those for charms written in Python or other languages. Using `goops` does not change the way you interact with Juju for these operations. For more information on these operations, refer to the [Juju documentation](https://documentation.ubuntu.com/juju/3.6/).

--- a/docs/how_to/perform_other_charm_operations.md
+++ b/docs/how_to/perform_other_charm_operations.md
@@ -2,6 +2,6 @@
 description: Perform other charm operations with `goops` charms.
 ---
 
-# Perform Other Charm Operations
+# How-to perform Other Charm Operations
 
 Other charm operations such as `deploying`, `publishing`, and `upgrading` are identical to those for charms written in Python or other languages. The `goops` charm framework does not change the way you interact with Juju for these operations. For more information on these operations, refer to the [Juju documentation](https://documentation.ubuntu.com/juju/3.6/).

--- a/docs/how_to/test_a_charm.md
+++ b/docs/how_to/test_a_charm.md
@@ -2,7 +2,7 @@
 description: Test a Juju charm using `goops` and `goopstest`.
 ---
 
-# Test a Charm
+# How-to test a Charm
 
 ## 1. Write the test cases
 

--- a/docs/how_to/write_a_charm.md
+++ b/docs/how_to/write_a_charm.md
@@ -2,7 +2,7 @@
 description: Write a Juju charm using `goops`
 ---
 
-# Write a Charm
+# How-to write a Charm
 
 Create a new directory for your charm project and initialize a Go module. Here the charm name is `example`, replace it with your desired charm name:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,25 +53,25 @@ func Configure() error {
 
     ---
 
-    **Start here**: a hands-on introduction to goops for new users. Build and deploy a Go charm in minutes.
+    **Start here**: a hands-on introduction to goops for new users. Write, build and deploy your first charm in minutes.
 
 -   [__How-to Guides__](how_to/index.md)
 
     ---
 
-    **Step-by-step guides** covering key operation and common tasks.
+    **Step-by-step guides** covering key operations such as managing config, integrations, and workloads.
 
 -   [__Reference__](reference/index.md)
 
     ---
 
-    **Technical information** - API, configuration, and more.
+    **Technical information** - API, example charms, charm libraries, best practices, and more.
 
 -   [__Explanation__](explanation/index.md)
 
     ---
 
-    **Discussion and clarification** of key topics.
+    **Discussion and clarification** of key topics like unit testing, and handling hooks.
 
 
 </div>

--- a/docs/reference/best_practices.md
+++ b/docs/reference/best_practices.md
@@ -4,7 +4,7 @@ description: Best practices for writing charms with `goops`.
 
 # Charm Development best Practices
 
-This document outlines best practices for writing charms using the `goops` framework. Following these practices will help ensure that your charm is robust.
+This document outlines best practices for writing robust charms using `goops`.
 
 ## Write idempotent charm code
 
@@ -23,6 +23,7 @@ Use `goopstest` to write unit tests for your charms in a state-transition style.
 Be wary of managing state in your charm code. Maintaining state becomes increasingly complex the longer the charm is deployed as users upgrade it and the charm code evolves.
 
 State includes:
+
 - Stored State
 - Secrets
 - Relation data

--- a/docs/reference/charm_libraries.md
+++ b/docs/reference/charm_libraries.md
@@ -10,3 +10,5 @@ We maintain a set of Charm Libraries for `goops` charms at [github.com/gruyaume/
 - [`loki_push_api`](https://github.com/gruyaume/charm-libraries/tree/main/logging): Push logs to a Loki instance.
 - [`prometheus_scrape`](https://github.com/gruyaume/charm-libraries/tree/main/prometheus): Send metrics related information to a Prometheus instance to allow scraping.
 - [`tracing`](https://github.com/gruyaume/charm-libraries/tree/main/tracing): Receive tracing URLs from a tracing server.
+
+If you need a Charm Library that is not listed here, consider creating it by contributing to the [charm-libraries repository](https://github.com/gruyaume/charm-libraries).

--- a/docs/reference/example_charms.md
+++ b/docs/reference/example_charms.md
@@ -7,8 +7,8 @@ description: Example Juju charms that use `goops`.
 The following charms use `goops` and can be used as reference implementations:
 
 - [**Certificates**](https://github.com/gruyaume/certificates-operator): A charm for provisioning TLS certificates using the `tls-certificates` integration.
-- [**Notary K8s**](https://github.com/gruyaume/notary-k8s-operator): A Kubernetes charm for Notary, a TLS certificate authority for enterprise applications.
-- [**LEGO**](https://github.com/gruyaume/lego-operator): A charm for managing Let's Encrypt certificates using the LEGO client.
-- [**Core K8s**](https://github.com/ellanetworks/core-k8s-operator): A Kubernetes charm for operating Ella Core, a 5G core network.
+- [**Notary K8s**](https://github.com/gruyaume/notary-k8s-operator): A Kubernetes charm for [Notary](https://github.com/canonical/notary), a TLS certificate authority for enterprise applications. It works on both Kubernetes and machine models.
+- [**LEGO**](https://github.com/gruyaume/lego-operator): A charm for managing Let's Encrypt certificates using the [LEGO](https://github.com/go-acme/lego) client. It works on both Kubernetes and machine models.
+- [**Core K8s**](https://github.com/ellanetworks/core-k8s-operator): A Kubernetes charm for operating [Ella Core](https://docs.ellanetworks.com/), a 5G core network.
 
 Feel free to explore these charms for practical examples of how to use `goops` in your own charms.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - Secrets: how_to/manage/secrets.md
       - Actions: how_to/manage/actions.md
       - State: how_to/manage/state.md
+      - Workloads (on Kubernetes): how_to/manage/workloads_on_k8s.md
   - Reference:
     - reference/index.md
     - Example Charms: reference/example_charms.md


### PR DESCRIPTION
# Description

- Add how-to manage workloads on k8s
- Add `how-to` prefix to all how-to guides
- Reverse options in `how-to manage integrations` so that the first option is the recommended one (to use charm libraries)
- Fix list formatting in `best practices`
- Add links to upstream projects for example charms
- Make index less generic
- Separate test structure from concepts

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
